### PR TITLE
feat(api): accept sharedFrom + iOS Shortcut docs

### DIFF
--- a/apps/api/app/controllers/bookmarks_controller.ts
+++ b/apps/api/app/controllers/bookmarks_controller.ts
@@ -36,7 +36,7 @@ export default class BookmarksController {
       enrichedAt: null,
       embeddingSourceText: null,
       savedCount: 1,
-      savedFrom: [],
+      savedFrom: payload.sharedFrom ? [payload.sharedFrom] : [],
     })
 
     await enrichmentQueue.dispatch(bookmark.id)

--- a/apps/api/app/validators/bookmark.ts
+++ b/apps/api/app/validators/bookmark.ts
@@ -1,9 +1,20 @@
 import vine from '@vinejs/vine'
 
+const SAVED_FROM_VALUES = [
+  'ios-shortcut',
+  'chrome-extension',
+  'firefox-extension',
+  'cli',
+  'mcp',
+  'import-csv',
+  'api',
+] as const
+
 export const createBookmarkValidator = vine.compile(
   vine.object({
     url: vine.string().url(),
     title: vine.string().optional(),
     content: vine.string().optional(),
+    sharedFrom: vine.enum(SAVED_FROM_VALUES).optional(),
   })
 )

--- a/apps/api/tests/functional/bookmark_ingest.spec.ts
+++ b/apps/api/tests/functional/bookmark_ingest.spec.ts
@@ -1,0 +1,42 @@
+import { test } from '@japa/runner'
+
+import { authHeader } from '#tests/helpers/api_key'
+
+test.group('POST /bookmarks — sharedFrom', (group) => {
+  let auth: { Authorization: string }
+  group.each.setup(async () => {
+    auth = await authHeader()
+  })
+
+  test('persists sharedFrom into savedFrom array', async ({ client, assert }) => {
+    const created = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://example.com/from-shortcut', sharedFrom: 'ios-shortcut' })
+
+    created.assertStatus(201)
+    assert.deepEqual(created.body().savedFrom, ['ios-shortcut'])
+
+    const fetched = await client.get(`/bookmarks/${created.body().id}`).headers(auth)
+    fetched.assertStatus(200)
+    assert.deepEqual(fetched.body().savedFrom, ['ios-shortcut'])
+  })
+
+  test('rejects unknown sharedFrom value with 422', async ({ client }) => {
+    const res = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://example.com/bad-source', sharedFrom: 'myspace' })
+    res.assertStatus(422)
+  })
+
+  test('omitting sharedFrom keeps savedFrom empty', async ({ client, assert }) => {
+    const res = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://example.com/no-source' })
+
+    res.assertStatus(201)
+    assert.deepEqual(res.body().savedFrom, [])
+  })
+})

--- a/tools/shortcut/README.md
+++ b/tools/shortcut/README.md
@@ -1,0 +1,96 @@
+# StashIt — Apple Shortcut
+
+iOS share-sheet client for StashIt. Share any URL from Safari, Twitter, YouTube, etc., and it lands as a bookmark in 1 second.
+
+## Install
+
+> The pre-built `.shortcut` binary and the iCloud share link are not yet published. Until they are, build it manually with the steps below — it takes ~2 minutes.
+
+### One-tap install (when available)
+
+1. Open the iCloud share link from your iPhone (link will be added to the repo root README once published).
+2. Tap **Add Shortcut**.
+3. On first run, Shortcuts will ask for the API base URL and your API key.
+
+### Manual build
+
+The Shortcut is a small chain of actions. Build it once in the **Shortcuts** app, then run from any share sheet.
+
+#### 1. Create the input variables
+
+Open **Shortcuts** → **+** (new shortcut) → tap the settings icon → **Set up shortcut input**:
+
+- **Accept**: URLs only
+- **In share sheet**: ON
+- **Share sheet types**: URLs
+
+Then add two text variables (Actions panel → search "Text"):
+
+- `StashIt API URL` → e.g. `https://api.stashit.example.com`
+- `StashIt API Key` → your API key (the plaintext returned by `node ace key:create <name>`)
+
+You can also store these as **shortcut input variables** so you only set them once and they persist across runs.
+
+#### 2. Get the article body (optional, recommended)
+
+Add **Get Article Using Safari Reader** with input set to **Shortcut Input**.
+
+If Safari Reader fails (e.g. for Twitter or YouTube links), the Shortcut should still POST the URL alone — the API enriches server-side. Wrap the Reader call in an **If** block on `Shortcut Input` so unsupported URLs skip it.
+
+#### 3. POST to /bookmarks
+
+Add **Get Contents of URL**:
+
+- **URL**: `[StashIt API URL]/bookmarks`
+- **Method**: `POST`
+- **Headers**:
+  - `Authorization` → `Bearer [StashIt API Key]`
+  - `Content-Type` → `application/json`
+- **Request Body**: JSON
+  - `url` → Shortcut Input
+  - `title` → Article Name (from Safari Reader, optional)
+  - `content` → Article Body (from Safari Reader, optional)
+  - `sharedFrom` → `ios-shortcut`
+
+#### 4. Branch on the response status
+
+Use **Get Dictionary Value** to read the HTTP status from the previous action (or use **If** on the response body).
+
+- **201** → **Show Notification**: "Saved to StashIt"
+- **409** → **Show Notification**: "Already saved"
+- anything else → **Show Notification**: "StashIt error: [status]"
+
+#### 5. Name and pin
+
+Name the Shortcut `StashIt`. Optionally pin it to the top of the share sheet under **Shortcuts settings → Share sheet**.
+
+## Payload reference
+
+The Shortcut sends this body to `POST /bookmarks`:
+
+```json
+{
+  "url": "https://example.com/article",
+  "title": "Optional article title",
+  "content": "Optional Safari Reader text",
+  "sharedFrom": "ios-shortcut"
+}
+```
+
+Required: `url`. The rest is optional. `sharedFrom` must be one of: `ios-shortcut`, `chrome-extension`, `firefox-extension`, `cli`, `mcp`, `import-csv`, `api`.
+
+## Server responses
+
+| Status | Meaning                        | Shortcut behavior        |
+| ------ | ------------------------------ | ------------------------ |
+| 201    | New bookmark created           | "Saved to StashIt"       |
+| 409    | URL already saved (deduped)    | "Already saved"          |
+| 401    | Missing or invalid API key     | "Auth error — check key" |
+| 422    | Bad payload (e.g. invalid URL) | "Invalid URL"            |
+| 5xx    | Server error                   | "StashIt error — retry"  |
+
+## Troubleshooting
+
+- **"Auth error"** — regenerate the key with `node ace key:create <name>` and update the `StashIt API Key` variable.
+- **YouTube / Twitter share doesn't include URL text** — the share sheet sometimes passes the link as plain text. Make sure the Shortcut accepts both **URLs** and **Text** in its input settings, then coerce text to URL in the first step.
+- **Safari Reader fails on unsupported pages** — wrap the Reader action in an `If` block; on failure, POST without `title`/`content` and let the server enrich.


### PR DESCRIPTION
## Summary

Adds `sharedFrom` to the bookmark create payload (persisted into `savedFrom`) and ships manual setup docs for the iOS Shortcut share-sheet client. Closes #7.

## Changes

- `apps/api/app/validators/bookmark.ts` — accept optional `sharedFrom` enum (SavedFrom values)
- `apps/api/app/controllers/bookmarks_controller.ts` — write `[sharedFrom]` into `savedFrom` on create
- `apps/api/tests/functional/bookmark_ingest.spec.ts` — 3 tests: persists, rejects unknown values (422), omitting keeps `savedFrom: []`
- `tools/shortcut/README.md` — manual build steps, payload reference, status → notification mapping, troubleshooting

## Test plan

- [x] CI passes
- [x] Manual: build the Shortcut on iOS following the README and confirm sharing a Safari URL hits POST /bookmarks with sharedFrom=ios-shortcut