### PR TITLE
feat(infra): docker compose stack + self-hosting docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+**/node_modules
+**/build
+**/dist
+**/.adonisjs
+**/tmp
+**/.env
+**/.env.local
+**/.env.*.local
+**/.git
+**/.DS_Store
+**/.turbo
+**/coverage

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# ─── stashit — root env (used by docker-compose) ───────────────────────────────
+# Copy to `.env` and fill in. The api/worker containers read these via compose.
+
+# ─── App ───────────────────────────────────────────────────────────────────────
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+APP_KEY=replace_me_with_a_32_char_random_secret_xx
+APP_URL=http://localhost:3333
+LOG_LEVEL=info
+TZ=UTC
+
+# ─── API ───────────────────────────────────────────────────────────────────────
+# Host port the API container binds to (container always listens on 3333).
+API_PORT=3333
+
+# ─── Postgres ──────────────────────────────────────────────────────────────────
+POSTGRES_USER=stashit
+POSTGRES_PASSWORD=stashit
+POSTGRES_DB=stashit
+# Host port mapping for direct DB access (psql, GUI tools).
+POSTGRES_PORT=5435
+
+# ─── Redis ─────────────────────────────────────────────────────────────────────
+# Host port mapping. The api/worker containers reach Redis on the internal network.
+REDIS_PORT=6385

--- a/README.md
+++ b/README.md
@@ -8,7 +8,25 @@ stashit is a single-user, self-hosted bookmark backend designed to be consumed p
 
 ## Why
 
-Existing self-hosted bookmark managers (Linkding, Linkwarden, Karakeep) are UI-centric. stashit inverts the priority: the API is the product, the clients are thin shells around it. It is the natural memory layer for personal AI workflows — ask your agent *"find me that article about diffusion models I saved last month"* and get a usable answer.
+Existing self-hosted bookmark managers (Linkding, Linkwarden, Karakeep) are UI-centric. stashit inverts the priority: the API is the product, the clients are thin shells around it. It is the natural memory layer for personal AI workflows — ask your agent _"find me that article about diffusion models I saved last month"_ and get a usable answer.
+
+## Quick start
+
+```bash
+git clone https://github.com/Nardjo/stashit.git
+cd stashit
+cp .env.example .env
+# Generate APP_KEY:
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# Paste it into .env, then:
+docker compose up -d
+
+curl http://localhost:3333/   # → {"ok":true}
+docker compose exec api node ace key:create my-laptop
+```
+
+Full self-hosting guide (plain Docker, backup/restore): [docs/SELF_HOSTING.md](./docs/SELF_HOSTING.md).
+API reference: [docs/API.md](./docs/API.md).
 
 ## Planned clients
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1.7
+
+# ─── base ──────────────────────────────────────────────────────────────────────
+FROM node:22-alpine AS base
+RUN apk add --no-cache wget tini && \
+    corepack enable && \
+    corepack prepare pnpm@10.22.0 --activate
+WORKDIR /app
+ENV PNPM_HOME=/usr/local/share/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+
+# ─── deps ──────────────────────────────────────────────────────────────────────
+FROM base AS deps
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json tsconfig.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/shared/package.json ./packages/shared/
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+# ─── builder ───────────────────────────────────────────────────────────────────
+FROM deps AS builder
+COPY packages/shared ./packages/shared
+RUN pnpm --filter @stashit/shared build
+
+COPY apps/api ./apps/api
+RUN pnpm --filter @stashit/api build
+
+# ─── runner ────────────────────────────────────────────────────────────────────
+FROM base AS runner
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=3333
+ENV LOG_LEVEL=info
+ENV TZ=UTC
+
+RUN addgroup -S app && adduser -S app -G app
+
+COPY --from=builder /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/package.json ./
+COPY --from=builder /app/apps/api/package.json ./apps/api/
+COPY --from=builder /app/packages/shared/package.json ./packages/shared/
+COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
+COPY --from=builder /app/apps/api/build ./apps/api/build
+
+RUN pnpm install --frozen-lockfile --prod --filter @stashit/api... --ignore-scripts && \
+    chown -R app:app /app
+
+USER app
+WORKDIR /app/apps/api/build
+
+EXPOSE 3333
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -q -O- http://127.0.0.1:3333/ || exit 1
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["sh", "-c", "node ace migration:run --force && node bin/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,15 @@ services:
     container_name: stashit-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_USER: stashit
-      POSTGRES_PASSWORD: stashit
-      POSTGRES_DB: stashit
+      POSTGRES_USER: ${POSTGRES_USER:-stashit}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-stashit}
+      POSTGRES_DB: ${POSTGRES_DB:-stashit}
     ports:
-      - "5435:5432"
+      - "${POSTGRES_PORT:-5435}:5432"
     volumes:
       - stashit-pg-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U stashit -d stashit"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-stashit} -d ${POSTGRES_DB:-stashit}"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -22,7 +22,7 @@ services:
     container_name: stashit-redis
     restart: unless-stopped
     ports:
-      - "6385:6379"
+      - "${REDIS_PORT:-6385}:6379"
     volumes:
       - stashit-redis-data:/data
     healthcheck:
@@ -30,6 +30,61 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    container_name: stashit-api
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      HOST: 0.0.0.0
+      PORT: 3333
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      TZ: ${TZ:-UTC}
+      APP_KEY: ${APP_KEY}
+      APP_URL: ${APP_URL:-http://localhost:3333}
+      DATABASE_URL: postgres://${POSTGRES_USER:-stashit}:${POSTGRES_PASSWORD:-stashit}@postgres:5432/${POSTGRES_DB:-stashit}
+      REDIS_URL: redis://redis:6379
+    ports:
+      - "${API_PORT:-3333}:3333"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:3333/"]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+
+  worker:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    container_name: stashit-worker
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      HOST: 0.0.0.0
+      PORT: 3333
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      TZ: ${TZ:-UTC}
+      APP_KEY: ${APP_KEY}
+      APP_URL: ${APP_URL:-http://localhost:3333}
+      DATABASE_URL: postgres://${POSTGRES_USER:-stashit}:${POSTGRES_PASSWORD:-stashit}@postgres:5432/${POSTGRES_DB:-stashit}
+      REDIS_URL: redis://redis:6379
+    command: ["node", "ace", "queue:listen"]
 
 volumes:
   stashit-pg-data:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,137 @@
+# StashIt HTTP API
+
+Single-user, API-key authenticated. All requests except `GET /` require an `Authorization: Bearer <key>` header.
+
+> v1 reference. Auto-generated OpenAPI spec is on the roadmap.
+
+## Authentication
+
+Every protected endpoint expects:
+
+```
+Authorization: Bearer <plaintext-api-key>
+```
+
+API keys are created with the `key:create` ace command (see [SELF_HOSTING.md](./SELF_HOSTING.md)). The plaintext is shown **once** at creation; only a hash is stored.
+
+Failures:
+
+- `401 unauthorized` — missing or invalid header / unknown or revoked key.
+
+## Endpoints
+
+### `GET /`
+
+Health check. Public, no auth.
+
+**Response 200**
+
+```json
+{ "ok": true }
+```
+
+---
+
+### `POST /bookmarks`
+
+Create a bookmark. URL is normalized server-side (lowercased host, stripped tracking params, host aliases applied) and deduplicated by SHA-256 of the normalized URL.
+
+**Body**
+
+```json
+{
+  "url": "https://example.com/article",
+  "title": "Optional title",
+  "content": "Optional Safari Reader / extracted text",
+  "sharedFrom": "ios-shortcut"
+}
+```
+
+| Field        | Type                                                                                             | Required |
+| ------------ | ------------------------------------------------------------------------------------------------ | -------- |
+| `url`        | string (URL)                                                                                     | yes      |
+| `title`      | string                                                                                           | no       |
+| `content`    | string                                                                                           | no       |
+| `sharedFrom` | enum: `ios-shortcut`, `chrome-extension`, `firefox-extension`, `cli`, `mcp`, `import-csv`, `api` | no       |
+
+**Responses**
+
+- `201 Created` — new bookmark, body is the full Bookmark object (see schema below). `enrichmentStatus` starts as `pending`; an enrichment job is enqueued and transitions it to `done`.
+- `409 Conflict` — a bookmark with the same normalized URL already exists. Body is the existing bookmark.
+- `422 Unprocessable Entity` — invalid payload (missing/invalid `url`, unknown `sharedFrom` value).
+- `401 Unauthorized` — auth.
+
+---
+
+### `GET /bookmarks/:id`
+
+Fetch a single bookmark by UUID.
+
+**Responses**
+
+- `200 OK` — the bookmark.
+- `404 Not Found` — `{ "error": "not_found", "message": "Bookmark not found" }`.
+- `401 Unauthorized` — auth.
+
+---
+
+### `DELETE /bookmarks/:id`
+
+Hard-delete a bookmark.
+
+**Responses**
+
+- `204 No Content`
+- `404 Not Found` — `{ "error": "not_found", "message": "Bookmark not found" }`.
+- `401 Unauthorized` — auth.
+
+## Bookmark schema
+
+```ts
+{
+  id: string,                                        // UUID v4
+  url: string,                                       // normalized
+  urlHash: string,                                   // 64-char hex (SHA-256 of url)
+  type: "tweet" | "youtube" | "article" | "image" | "pdf" | "other",
+  title: string,
+  description: string,
+  tags: string[],
+  ogImage: string | null,
+  embedData: unknown | null,
+  enrichmentStatus: "pending" | "enriching" | "done" | "degraded" | "failed",
+  enrichmentError: string | null,
+  enrichmentFailureReason: "url_dead" | "fetch_unavailable" | "llm_invalid_output" | "llm_provider_error" | "unknown" | null,
+  enrichmentAttempts: number,
+  enrichedAt: string | null,                         // ISO datetime
+  embeddingSourceText: string | null,
+  savedAt: string,                                   // ISO datetime
+  savedCount: number,
+  lastSavedAt: string,                               // ISO datetime
+  savedFrom: ("ios-shortcut" | "chrome-extension" | "firefox-extension" | "cli" | "mcp" | "import-csv" | "api")[]
+}
+```
+
+## Errors
+
+All error responses follow:
+
+```json
+{
+  "error": "<machine_code>",
+  "message": "<human readable>",
+  "details": {}
+}
+```
+
+`details` is included for validation errors (422) and lists per-field issues.
+
+## Rate limiting
+
+None in v1. Single-user expected. Add a reverse proxy (Caddy, Traefik, nginx) if you expose the API publicly.
+
+## Roadmap
+
+- `POST /search` — semantic + keyword search with pgvector
+- `GET /bookmarks` — paginated list, filter by tags / type / status
+- `PATCH /bookmarks/:id` — edit title, tags, description
+- OpenAPI spec auto-generation

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,143 @@
+# Self-hosting StashIt
+
+Two ways to run StashIt: **Docker Compose** (simplest) and **plain Docker** (manual).
+
+Both give you the same artifact: an HTTP API on port 3333, backed by Postgres (pgvector) + Redis, with an enrichment worker running alongside.
+
+## Quick start (Docker Compose)
+
+```bash
+git clone https://github.com/Nardjo/stashit.git
+cd stashit
+cp .env.example .env
+
+# Generate a strong APP_KEY (32+ chars)
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# Paste into .env as APP_KEY=...
+
+docker compose up -d
+```
+
+The first boot builds the image (~2 min), then runs migrations automatically. Verify:
+
+```bash
+curl http://localhost:3333/
+# → {"ok":true}
+```
+
+Create your first API key:
+
+```bash
+docker compose exec api node ace key:create my-laptop
+# → copy the plaintext, you'll never see it again
+```
+
+Test the API:
+
+```bash
+curl -X POST http://localhost:3333/bookmarks \
+  -H "Authorization: Bearer <plaintext-from-above>" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com"}'
+```
+
+## Environment reference
+
+| Variable            | Required | Default                 | Notes                                                                 |
+| ------------------- | -------- | ----------------------- | --------------------------------------------------------------------- |
+| `APP_KEY`           | yes      | —                       | 32+ char secret. Used for cookie/signed-URL crypto. Rotate carefully. |
+| `APP_URL`           | yes      | `http://localhost:3333` | Public URL the API is reachable at.                                   |
+| `LOG_LEVEL`         | no       | `info`                  | `trace`, `debug`, `info`, `warn`, `error`, `silent`.                  |
+| `TZ`                | no       | `UTC`                   | Container timezone.                                                   |
+| `API_PORT`          | no       | `3333`                  | Host port mapping. Container always listens on 3333.                  |
+| `POSTGRES_USER`     | no       | `stashit`               |                                                                       |
+| `POSTGRES_PASSWORD` | no       | `stashit`               | **Change for production.**                                            |
+| `POSTGRES_DB`       | no       | `stashit`               |                                                                       |
+| `POSTGRES_PORT`     | no       | `5435`                  | Host port for direct psql access.                                     |
+| `REDIS_PORT`        | no       | `6385`                  | Host port. Containers reach Redis on the internal network.            |
+
+## Plain Docker (no compose)
+
+If you'd rather wire it manually:
+
+```bash
+docker network create stashit
+
+docker run -d --name stashit-postgres --network stashit \
+  -e POSTGRES_USER=stashit -e POSTGRES_PASSWORD=stashit -e POSTGRES_DB=stashit \
+  -v stashit-pg-data:/var/lib/postgresql/data \
+  pgvector/pgvector:pg16
+
+docker run -d --name stashit-redis --network stashit \
+  -v stashit-redis-data:/data \
+  redis:7-alpine
+
+docker build -t stashit-api -f apps/api/Dockerfile .
+
+docker run -d --name stashit-api --network stashit \
+  -e APP_KEY=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))") \
+  -e APP_URL=http://localhost:3333 \
+  -e DATABASE_URL=postgres://stashit:stashit@stashit-postgres:5432/stashit \
+  -e REDIS_URL=redis://stashit-redis:6379 \
+  -p 3333:3333 \
+  stashit-api
+
+docker run -d --name stashit-worker --network stashit \
+  -e APP_KEY=<same-as-api> \
+  -e APP_URL=http://localhost:3333 \
+  -e DATABASE_URL=postgres://stashit:stashit@stashit-postgres:5432/stashit \
+  -e REDIS_URL=redis://stashit-redis:6379 \
+  -e HOST=0.0.0.0 -e PORT=3333 \
+  stashit-api node ace queue:listen
+```
+
+## Backup & restore
+
+**Backup** (with the stack running):
+
+```bash
+docker compose exec -T postgres \
+  pg_dump -U stashit -d stashit --format=custom --no-owner \
+  > stashit-$(date +%Y%m%d-%H%M%S).dump
+```
+
+**Restore** to a clean stack:
+
+```bash
+# Stop the api/worker so nothing writes during restore
+docker compose stop api worker
+
+# Drop + recreate the database
+docker compose exec -T postgres \
+  psql -U stashit -d postgres -c "DROP DATABASE stashit; CREATE DATABASE stashit;"
+
+# Restore
+cat stashit-20260427-120000.dump | \
+  docker compose exec -T postgres pg_restore -U stashit -d stashit --no-owner
+
+# Restart the app
+docker compose start api worker
+```
+
+> `pgvector` extension is provisioned on first migration (`1_enable_pgvector`). After a restore on a fresh database, run migrations once: `docker compose exec api node ace migration:run --force`.
+
+## Upgrades
+
+```bash
+git pull
+docker compose build --no-cache api
+docker compose up -d
+```
+
+Migrations run automatically on container start (the `api` service entrypoint runs `node ace migration:run --force` before booting the server).
+
+## Logs & troubleshooting
+
+```bash
+docker compose logs -f api worker
+```
+
+- **API hangs on first start** → likely waiting for postgres healthcheck. Check `docker compose logs postgres`.
+- **`extension "vector" is not available`** → wrong Postgres image. Must be `pgvector/pgvector:pg16`, not vanilla `postgres:16`.
+- **`401 unauthorized` on every request** → no API key created or wrong header format. Use `Authorization: Bearer <plaintext>`.
+- **Bookmarks stay in `pending`** → worker container not running or can't reach Redis. Check `docker compose logs worker`.


### PR DESCRIPTION
## Summary

Adds a complete self-hosting story: multi-stage Dockerfile for the API, full docker-compose stack (postgres + redis + api + worker), root .env.example, and SELF_HOSTING.md / API.md docs. Closes #8.

## Changes

- `apps/api/Dockerfile` — multi-stage pnpm build, non-root user, tini, healthcheck, auto-runs migrations on boot
- `.dockerignore` — excludes node_modules, build artifacts, .env, .git
- `docker-compose.yml` — adds `api` and `worker` services with healthcheck deps, env-driven config
- `.env.example` — root env file consumed by compose
- `docs/SELF_HOSTING.md` — quick start, env reference table, plain Docker recipe, backup/restore via pg_dump, troubleshooting
- `docs/API.md` — endpoint reference (auth, GET /, POST/GET/DELETE /bookmarks), bookmark schema, error format
- `README.md` — quick start section linking to the new docs

## Test plan

- [x] CI passes
- [x] Verify `cp .env.example .env && docker compose up -d` on a fresh checkout reaches \`{"ok":true}\` on http://localhost:3333/