### PR TITLE
feat(api): embeddings + pgvector storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,10 @@ REDIS_PORT=6385
 STASHIT_LLM_PROVIDER=anthropic
 STASHIT_LLM_MODEL=claude-sonnet-4-5
 STASHIT_LLM_API_KEY=
+
+# ─── Embedding (Vercel AI SDK) ─────────────────────────────────────────────────
+# Provider one of: openai
+# Model must output exactly 1536 dims for v1 (default: text-embedding-3-small).
+STASHIT_EMBEDDING_PROVIDER=openai
+STASHIT_EMBEDDING_MODEL=text-embedding-3-small
+STASHIT_EMBEDDING_API_KEY=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -16,3 +16,10 @@ REDIS_URL=redis://localhost:6385
 STASHIT_LLM_PROVIDER=anthropic
 STASHIT_LLM_MODEL=claude-sonnet-4-5
 STASHIT_LLM_API_KEY=
+
+# Embedding (Vercel AI SDK)
+# Provider one of: openai
+# Model must output exactly 1536 dims for v1 (default: text-embedding-3-small).
+STASHIT_EMBEDDING_PROVIDER=openai
+STASHIT_EMBEDDING_MODEL=text-embedding-3-small
+STASHIT_EMBEDDING_API_KEY=

--- a/apps/api/app/jobs/enrich_bookmark_job.ts
+++ b/apps/api/app/jobs/enrich_bookmark_job.ts
@@ -1,10 +1,28 @@
 import app from '@adonisjs/core/services/app'
 import db from '@adonisjs/lucid/services/db'
+import type { EnrichmentFailureReason } from '@stashit/shared'
 import { DateTime } from 'luxon'
 
 import Bookmark from '#models/bookmark'
+import { composeEmbeddingSource } from '#services/compose_embedding_source'
+import { embedBookmarkSource } from '#services/embed_bookmark_source'
+import EmbeddingProvider from '#services/embedding_provider'
 import { enrichBookmark } from '#services/enrich_bookmark'
 import LlmProvider from '#services/llm_provider'
+
+class StageError extends Error {
+  constructor(
+    public stage: 'llm' | 'embedding',
+    message: string
+  ) {
+    super(message)
+  }
+}
+
+const FAILURE_REASON: Record<StageError['stage'], EnrichmentFailureReason> = {
+  llm: 'llm_provider_error',
+  embedding: 'embedding_provider_error',
+}
 
 export default class EnrichBookmarkJob {
   static async handle(bookmarkId: string, content?: string): Promise<void> {
@@ -16,21 +34,27 @@ export default class EnrichBookmarkJob {
     await bookmark.save()
 
     try {
-      const provider = await app.container.make(LlmProvider)
-      const model = await provider.getModel()
-      const existingTags = await fetchExistingTags()
       const sourceText = (content && content.trim()) || bookmark.title || bookmark.url
 
-      const result = await enrichBookmark({
+      const enrichment = await runLlm(sourceText)
+
+      bookmark.title = enrichment.title
+      bookmark.description = enrichment.description
+      bookmark.tags = enrichment.tags
+      bookmark.type = enrichment.type
+
+      const embeddingSourceText = composeEmbeddingSource({
+        title: enrichment.title,
+        type: enrichment.type,
+        tags: enrichment.tags,
+        description: enrichment.description,
         content: sourceText,
-        existingTags,
-        model,
       })
 
-      bookmark.title = result.title
-      bookmark.description = result.description
-      bookmark.tags = result.tags
-      bookmark.type = result.type
+      const vector = await runEmbedding(embeddingSourceText)
+      await persistEmbedding(bookmark.id, vector, embeddingSourceText)
+
+      bookmark.embeddingSourceText = embeddingSourceText
       bookmark.enrichmentStatus = 'done'
       bookmark.enrichmentError = null
       bookmark.enrichmentFailureReason = null
@@ -39,10 +63,46 @@ export default class EnrichBookmarkJob {
     } catch (err) {
       bookmark.enrichmentStatus = 'failed'
       bookmark.enrichmentError = err instanceof Error ? err.message : String(err)
-      bookmark.enrichmentFailureReason = 'llm_provider_error'
+      bookmark.enrichmentFailureReason =
+        err instanceof StageError ? FAILURE_REASON[err.stage] : 'llm_provider_error'
       await bookmark.save()
     }
   }
+}
+
+async function runLlm(sourceText: string) {
+  try {
+    const provider = await app.container.make(LlmProvider)
+    const model = await provider.getModel()
+    const existingTags = await fetchExistingTags()
+    return await enrichBookmark({ content: sourceText, existingTags, model })
+  } catch (err) {
+    throw new StageError('llm', err instanceof Error ? err.message : String(err))
+  }
+}
+
+async function runEmbedding(sourceText: string): Promise<number[]> {
+  try {
+    const provider = await app.container.make(EmbeddingProvider)
+    const model = await provider.getModel()
+    return await embedBookmarkSource({ sourceText, model })
+  } catch (err) {
+    throw new StageError('embedding', err instanceof Error ? err.message : String(err))
+  }
+}
+
+async function persistEmbedding(
+  bookmarkId: string,
+  vector: number[],
+  sourceText: string
+): Promise<void> {
+  const literal = `[${vector.join(',')}]`
+  await db.rawQuery(
+    `UPDATE bookmarks
+     SET embedding = ?::vector, embedding_source_text = ?
+     WHERE id = ?`,
+    [literal, sourceText, bookmarkId]
+  )
 }
 
 async function fetchExistingTags(): Promise<string[]> {

--- a/apps/api/app/services/compose_embedding_source.ts
+++ b/apps/api/app/services/compose_embedding_source.ts
@@ -1,0 +1,27 @@
+import type { BookmarkType } from '@stashit/shared'
+
+export interface ComposeEmbeddingSourceInput {
+  title: string
+  type: BookmarkType
+  tags: string[]
+  description: string
+  content: string
+}
+
+// Char-based proxy for ~2000 tokens (≈4 chars/token). No real tokenizer to keep
+// the dependency surface minimal; cap is conservative against the 8191-token
+// limit of text-embedding-3-small.
+const EXCERPT_CHAR_CAP = 8000
+
+export function composeEmbeddingSource(input: ComposeEmbeddingSourceInput): string {
+  const { title, type, tags, description, content } = input
+  const excerpt = content.length > EXCERPT_CHAR_CAP ? content.slice(0, EXCERPT_CHAR_CAP) : content
+
+  return [
+    `Title: ${title}`,
+    `Type: ${type}`,
+    `Tags: ${tags.join(', ')}`,
+    `Summary: ${description}`,
+    `Content excerpt:\n${excerpt}`,
+  ].join('\n')
+}

--- a/apps/api/app/services/embed_bookmark_source.ts
+++ b/apps/api/app/services/embed_bookmark_source.ts
@@ -1,0 +1,14 @@
+import { embed, type EmbeddingModel } from 'ai'
+
+export interface EmbedBookmarkSourceInput {
+  sourceText: string
+  model: EmbeddingModel
+}
+
+export async function embedBookmarkSource(input: EmbedBookmarkSourceInput): Promise<number[]> {
+  const { embedding } = await embed({
+    model: input.model,
+    value: input.sourceText,
+  })
+  return embedding
+}

--- a/apps/api/app/services/embedding_provider.ts
+++ b/apps/api/app/services/embedding_provider.ts
@@ -1,0 +1,33 @@
+import type { EmbeddingModelV3 } from '@ai-sdk/provider'
+import type { EmbeddingModel } from 'ai'
+
+import env from '#start/env'
+
+export type SupportedEmbeddingProvider = 'openai'
+
+export default class EmbeddingProvider {
+  async getModel(): Promise<EmbeddingModel> {
+    const provider = env.get('STASHIT_EMBEDDING_PROVIDER') as SupportedEmbeddingProvider | undefined
+    const modelId = env.get('STASHIT_EMBEDDING_MODEL')
+    const apiKey = env.get('STASHIT_EMBEDDING_API_KEY')
+
+    if (!provider) throw new Error('STASHIT_EMBEDDING_PROVIDER not configured')
+    if (!modelId) throw new Error('STASHIT_EMBEDDING_MODEL not configured')
+    if (!apiKey) throw new Error('STASHIT_EMBEDDING_API_KEY not configured')
+
+    return resolveEmbeddingModel(provider, modelId, apiKey)
+  }
+}
+
+export async function resolveEmbeddingModel(
+  provider: SupportedEmbeddingProvider,
+  modelId: string,
+  apiKey: string
+): Promise<EmbeddingModelV3> {
+  switch (provider) {
+    case 'openai': {
+      const { createOpenAI } = await import('@ai-sdk/openai')
+      return createOpenAI({ apiKey }).embedding(modelId)
+    }
+  }
+}

--- a/apps/api/database/migrations/4_add_hnsw_index_on_embedding.ts
+++ b/apps/api/database/migrations/4_add_hnsw_index_on_embedding.ts
@@ -1,0 +1,14 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  async up() {
+    this.schema.raw(
+      `CREATE INDEX bookmarks_embedding_hnsw_idx
+       ON bookmarks USING hnsw (embedding vector_cosine_ops)`
+    )
+  }
+
+  async down() {
+    this.schema.raw('DROP INDEX IF EXISTS bookmarks_embedding_hnsw_idx')
+  }
+}

--- a/apps/api/start/env.ts
+++ b/apps/api/start/env.ts
@@ -21,4 +21,8 @@ export default await Env.create(new URL('../', import.meta.url), {
   ] as const),
   STASHIT_LLM_MODEL: Env.schema.string.optional(),
   STASHIT_LLM_API_KEY: Env.schema.string.optional(),
+
+  STASHIT_EMBEDDING_PROVIDER: Env.schema.enum.optional(['openai'] as const),
+  STASHIT_EMBEDDING_MODEL: Env.schema.string.optional(),
+  STASHIT_EMBEDDING_API_KEY: Env.schema.string.optional(),
 })

--- a/apps/api/tests/functional/embedding.spec.ts
+++ b/apps/api/tests/functional/embedding.spec.ts
@@ -1,0 +1,126 @@
+import app from '@adonisjs/core/services/app'
+import db from '@adonisjs/lucid/services/db'
+import { test } from '@japa/runner'
+
+import EmbeddingProvider from '#services/embedding_provider'
+import enrichmentQueue from '#services/enrichment_queue'
+import LlmProvider from '#services/llm_provider'
+import { authHeader } from '#tests/helpers/api_key'
+import { mockEmbeddingReturning } from '#tests/helpers/mock_embedding'
+import { mockModelReturning } from '#tests/helpers/mock_llm'
+
+function mockLlm(json: object): LlmProvider {
+  return {
+    getModel: async () => mockModelReturning(json),
+  } as unknown as LlmProvider
+}
+
+function mockEmbedding(vector: number[]): EmbeddingProvider {
+  return {
+    getModel: async () => mockEmbeddingReturning(vector),
+  } as unknown as EmbeddingProvider
+}
+
+test.group('Embedding pipeline (E2E)', (group) => {
+  let auth: { Authorization: string }
+  group.each.setup(async () => {
+    auth = await authHeader()
+  })
+  group.each.teardown(() => {
+    app.container.restoreAll()
+  })
+
+  test('after enrichment, bookmark row has 1536-dim embedding and embedding_source_text', async ({
+    client,
+    assert,
+  }) => {
+    app.container.swap(LlmProvider, () =>
+      mockLlm({
+        title: 'Why Kubernetes Won',
+        description: 'Container orchestration history.',
+        tags: ['kubernetes', 'devops'],
+        type: 'article',
+      })
+    )
+
+    const expectedVector = Array.from({ length: 1536 }, (_, i) => (i % 7) / 10)
+    app.container.swap(EmbeddingProvider, () => mockEmbedding(expectedVector))
+
+    const created = await client.post('/bookmarks').headers(auth).json({
+      url: 'https://k8s.example.com/embed-test',
+      content: 'Long-form content about kubernetes.',
+    })
+    created.assertStatus(201)
+
+    await enrichmentQueue.flush()
+
+    const after = await client.get(`/bookmarks/${created.body().id}`).headers(auth)
+    assert.equal(after.body().enrichmentStatus, 'done')
+
+    const rows = await db.rawQuery(
+      `SELECT embedding::text AS embedding_text, embedding_source_text
+       FROM bookmarks WHERE id = ?`,
+      [created.body().id]
+    )
+    const row = (rows.rows ?? rows)[0]
+
+    assert.isString(row.embedding_text)
+    assert.match(row.embedding_text, /^\[/)
+    const dims = row.embedding_text.replace(/^\[|\]$/g, '').split(',').length
+    assert.equal(dims, 1536)
+
+    assert.isString(row.embedding_source_text)
+    assert.include(row.embedding_source_text, 'Title: Why Kubernetes Won')
+    assert.include(row.embedding_source_text, 'Type: article')
+    assert.include(row.embedding_source_text, 'Tags: kubernetes, devops')
+    assert.include(row.embedding_source_text, 'Summary: Container orchestration history.')
+    assert.include(row.embedding_source_text, 'Content excerpt:')
+  })
+
+  test('embedding provider error → status=failed with embedding_provider_error reason', async ({
+    client,
+    assert,
+  }) => {
+    app.container.swap(LlmProvider, () =>
+      mockLlm({
+        title: 't',
+        description: 'd',
+        tags: ['x'],
+        type: 'article',
+      })
+    )
+
+    app.container.swap(
+      EmbeddingProvider,
+      () =>
+        ({
+          getModel: async () => {
+            throw new Error('boom: embedding api down')
+          },
+        }) as unknown as EmbeddingProvider
+    )
+
+    const created = await client.post('/bookmarks').headers(auth).json({
+      url: 'https://embed-fail.example.com/post',
+      content: 'whatever',
+    })
+    created.assertStatus(201)
+
+    await enrichmentQueue.flush()
+
+    const after = await client.get(`/bookmarks/${created.body().id}`).headers(auth)
+    const body = after.body()
+    assert.equal(body.enrichmentStatus, 'failed')
+    assert.equal(body.enrichmentFailureReason, 'embedding_provider_error')
+    assert.match(body.enrichmentError, /boom/)
+  })
+
+  test('HNSW cosine index exists on bookmarks.embedding', async ({ assert }) => {
+    const rows = await db.rawQuery(
+      `SELECT indexname FROM pg_indexes
+       WHERE tablename = 'bookmarks' AND indexname = 'bookmarks_embedding_hnsw_idx'`
+    )
+    const records = rows.rows ?? rows
+    assert.equal(records.length, 1)
+  })
+})

--- a/apps/api/tests/functional/llm_enrichment.spec.ts
+++ b/apps/api/tests/functional/llm_enrichment.spec.ts
@@ -1,15 +1,23 @@
 import app from '@adonisjs/core/services/app'
 import { test } from '@japa/runner'
 
+import EmbeddingProvider from '#services/embedding_provider'
 import enrichmentQueue from '#services/enrichment_queue'
 import LlmProvider from '#services/llm_provider'
 import { authHeader } from '#tests/helpers/api_key'
+import { mockEmbeddingReturning } from '#tests/helpers/mock_embedding'
 import { mockModelReturning } from '#tests/helpers/mock_llm'
 
 function mockProvider(json: object): LlmProvider {
   return {
     getModel: async () => mockModelReturning(json),
   } as unknown as LlmProvider
+}
+
+function mockEmbedding(): EmbeddingProvider {
+  return {
+    getModel: async () => mockEmbeddingReturning(new Array(1536).fill(0.01)),
+  } as unknown as EmbeddingProvider
 }
 
 test.group('LLM enrichment (E2E)', (group) => {
@@ -64,6 +72,7 @@ test.group('LLM enrichment (E2E)', (group) => {
         type: 'article',
       })
     )
+    app.container.swap(EmbeddingProvider, () => mockEmbedding())
 
     const created = await client.post('/bookmarks').headers(auth).json({
       url: 'https://k8s.example.com/post',

--- a/apps/api/tests/helpers/mock_embedding.ts
+++ b/apps/api/tests/helpers/mock_embedding.ts
@@ -1,0 +1,27 @@
+import { MockEmbeddingModelV3 } from 'ai/test'
+
+export function mockEmbeddingReturning(vector: number[]): MockEmbeddingModelV3 {
+  return new MockEmbeddingModelV3({
+    doEmbed: async () => ({
+      embeddings: [vector],
+      usage: { tokens: 10 },
+      warnings: [],
+    }),
+  })
+}
+
+export function mockEmbeddingCapturing(
+  vector: number[],
+  capture: (value: string) => void
+): MockEmbeddingModelV3 {
+  return new MockEmbeddingModelV3({
+    doEmbed: async ({ values }) => {
+      if (values[0]) capture(values[0])
+      return {
+        embeddings: [vector],
+        usage: { tokens: 10 },
+        warnings: [],
+      }
+    },
+  })
+}

--- a/apps/api/tests/unit/compose_embedding_source.spec.ts
+++ b/apps/api/tests/unit/compose_embedding_source.spec.ts
@@ -1,0 +1,47 @@
+import { test } from '@japa/runner'
+
+import { composeEmbeddingSource } from '#services/compose_embedding_source'
+
+test.group('composeEmbeddingSource', () => {
+  test('builds Title / Type / Tags / Summary / Content excerpt layout', ({ assert }) => {
+    const text = composeEmbeddingSource({
+      title: 'Why Kubernetes Won',
+      type: 'article',
+      tags: ['kubernetes', 'devops'],
+      description: 'A short take on container orchestration history.',
+      content: 'Kubernetes won because it was open and ubiquitous.',
+    })
+
+    assert.match(text, /^Title: Why Kubernetes Won$/m)
+    assert.match(text, /^Type: article$/m)
+    assert.match(text, /^Tags: kubernetes, devops$/m)
+    assert.match(text, /^Summary: A short take on container orchestration history\.$/m)
+    assert.include(text, 'Content excerpt:')
+    assert.include(text, 'Kubernetes won because it was open and ubiquitous.')
+
+    const titleIdx = text.indexOf('Title:')
+    const typeIdx = text.indexOf('Type:')
+    const tagsIdx = text.indexOf('Tags:')
+    const summaryIdx = text.indexOf('Summary:')
+    const excerptIdx = text.indexOf('Content excerpt:')
+    assert.isTrue(titleIdx < typeIdx)
+    assert.isTrue(typeIdx < tagsIdx)
+    assert.isTrue(tagsIdx < summaryIdx)
+    assert.isTrue(summaryIdx < excerptIdx)
+  })
+
+  test('truncates content excerpt to ~2000 token cap (≈8000 chars)', ({ assert }) => {
+    const longContent = 'x'.repeat(20000)
+    const text = composeEmbeddingSource({
+      title: 't',
+      type: 'article',
+      tags: [],
+      description: 'd',
+      content: longContent,
+    })
+
+    const excerpt = text.slice(text.indexOf('Content excerpt:\n') + 'Content excerpt:\n'.length)
+    assert.isAtMost(excerpt.length, 8000)
+    assert.isAbove(excerpt.length, 7000)
+  })
+})

--- a/apps/api/tests/unit/embed_bookmark_source.spec.ts
+++ b/apps/api/tests/unit/embed_bookmark_source.spec.ts
@@ -1,0 +1,27 @@
+import { test } from '@japa/runner'
+
+import { embedBookmarkSource } from '#services/embed_bookmark_source'
+import { mockEmbeddingCapturing, mockEmbeddingReturning } from '#tests/helpers/mock_embedding'
+
+test.group('embedBookmarkSource', () => {
+  test('passes the source text to the embedding model', async ({ assert }) => {
+    let captured = ''
+    const model = mockEmbeddingCapturing(new Array(1536).fill(0.1), (v) => {
+      captured = v
+    })
+
+    await embedBookmarkSource({ sourceText: 'Title: x\nType: article\n...', model })
+
+    assert.equal(captured, 'Title: x\nType: article\n...')
+  })
+
+  test('returns the numeric vector from the model', async ({ assert }) => {
+    const expected = Array.from({ length: 1536 }, (_, i) => i / 1536)
+    const model = mockEmbeddingReturning(expected)
+
+    const vector = await embedBookmarkSource({ sourceText: 'whatever', model })
+
+    assert.equal(vector.length, 1536)
+    assert.deepEqual(vector, expected)
+  })
+})

--- a/apps/api/tests/unit/embedding_provider.spec.ts
+++ b/apps/api/tests/unit/embedding_provider.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@japa/runner'
+
+import { resolveEmbeddingModel } from '#services/embedding_provider'
+
+test.group('EmbeddingProvider.resolveEmbeddingModel', () => {
+  test('resolves openai embedding provider', async ({ assert }) => {
+    const m = await resolveEmbeddingModel('openai', 'text-embedding-3-small', 'sk-test')
+    assert.match(m.provider, /openai/)
+    assert.equal(m.modelId, 'text-embedding-3-small')
+  })
+})

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,13 +1,6 @@
 import { z } from "zod";
 
-export const BookmarkTypeSchema = z.enum([
-  "tweet",
-  "youtube",
-  "article",
-  "image",
-  "pdf",
-  "other",
-]);
+export const BookmarkTypeSchema = z.enum(["tweet", "youtube", "article", "image", "pdf", "other"]);
 export type BookmarkType = z.infer<typeof BookmarkTypeSchema>;
 
 export const EnrichmentStatusSchema = z.enum([
@@ -24,6 +17,7 @@ export const EnrichmentFailureReasonSchema = z.enum([
   "fetch_unavailable",
   "llm_invalid_output",
   "llm_provider_error",
+  "embedding_provider_error",
   "unknown",
 ]);
 export type EnrichmentFailureReason = z.infer<typeof EnrichmentFailureReasonSchema>;


### PR DESCRIPTION
Closes #10.

## Summary
- New `EmbeddingProvider` service mirroring `LlmProvider` (env: `STASHIT_EMBEDDING_PROVIDER` / `_MODEL` / `_API_KEY`). v1 supports `openai` (default `text-embedding-3-small`, 1536 dims).
- Job composes `embeddingSourceText` (`Title / Type / Tags / Summary / Content excerpt`, capped ≈ 2000 tokens / 8000 chars) after LLM enrichment, calls `embed()` (Vercel AI SDK), and persists the vector via raw `::vector` SQL plus the source text (for future re-embed without refetch).
- New migration adds an HNSW cosine index on `bookmarks.embedding`.
- Embedding-stage failures are isolated: new `embedding_provider_error` failure reason in the shared schema (distinct from `llm_provider_error`).

## Test plan
- [x] Unit: `composeEmbeddingSource` layout + truncation
- [x] Unit: `EmbeddingProvider.resolveEmbeddingModel` resolves OpenAI
- [x] Unit: `embedBookmarkSource` passes source text to model and returns vector
- [x] Functional E2E: bookmark row has 1536-dim `embedding` + populated `embedding_source_text` after enrichment
- [x] Functional E2E: embedding-stage failure → `status=failed` with `embedding_provider_error`
- [x] Functional E2E: `bookmarks_embedding_hnsw_idx` exists in `pg_indexes`
- [x] `node ace test` — 44/44 passing
- [x] `tsc --noEmit` clean