### PR TITLE
feat(api): read endpoints (search, list, tags, failed, refresh)

### DIFF
--- a/apps/api/app/controllers/bookmarks_controller.ts
+++ b/apps/api/app/controllers/bookmarks_controller.ts
@@ -3,11 +3,78 @@ import { randomUUID } from 'node:crypto'
 import type { HttpContext } from '@adonisjs/core/http'
 import { hashUrl, normalizeUrl } from '@stashit/shared'
 
+import db from '@adonisjs/lucid/services/db'
+import vine from '@vinejs/vine'
+
 import Bookmark from '#models/bookmark'
 import enrichmentQueue from '#services/enrichment_queue'
 import { createBookmarkValidator } from '#validators/bookmark'
 
+const indexValidator = vine.compile(
+  vine.object({
+    limit: vine.number().positive().max(200).optional(),
+    offset: vine.number().min(0).optional(),
+    type: vine.enum(['tweet', 'youtube', 'article', 'image', 'pdf', 'other'] as const).optional(),
+    tag: vine.string().minLength(1).optional(),
+  })
+)
+
 export default class BookmarksController {
+  async failed({ request }: HttpContext) {
+    const q = await indexValidator.validate(request.qs())
+    const limit = q.limit ?? 50
+    const offset = q.offset ?? 0
+
+    const params: unknown[] = []
+    const wheres = [`enrichment_status = 'failed'`]
+    if (q.type) {
+      params.push(q.type)
+      wheres.push(`type = ?`)
+    }
+    params.push(limit, offset)
+
+    const result = await db.rawQuery(
+      `SELECT * FROM bookmarks
+       WHERE ${wheres.join(' AND ')}
+       ORDER BY saved_at DESC
+       LIMIT ? OFFSET ?`,
+      params
+    )
+    const rows: Array<Record<string, unknown>> = result.rows ?? result
+    return { results: rows.map(serializeBookmarkRow) }
+  }
+
+  async index({ request }: HttpContext) {
+    const q = await indexValidator.validate(request.qs())
+    const limit = q.limit ?? 50
+    const offset = q.offset ?? 0
+
+    const params: unknown[] = []
+    const wheres = [`enrichment_status IN ('done', 'degraded')`]
+
+    if (q.type) {
+      params.push(q.type)
+      wheres.push(`type = ?`)
+    }
+    if (q.tag) {
+      params.push(q.tag)
+      wheres.push(
+        `EXISTS (SELECT 1 FROM jsonb_array_elements_text(tags) AS t(name) WHERE t.name = ?)`
+      )
+    }
+    params.push(limit, offset)
+
+    const result = await db.rawQuery(
+      `SELECT * FROM bookmarks
+       WHERE ${wheres.join(' AND ')}
+       ORDER BY saved_at DESC
+       LIMIT ? OFFSET ?`,
+      params
+    )
+    const rows: Array<Record<string, unknown>> = result.rows ?? result
+    return { results: rows.map(serializeBookmarkRow) }
+  }
+
   async store({ request, response }: HttpContext) {
     const payload = await request.validateUsing(createBookmarkValidator)
 
@@ -52,6 +119,19 @@ export default class BookmarksController {
     return bookmark
   }
 
+  async refresh({ params, response }: HttpContext) {
+    const bookmark = await Bookmark.find(params.id)
+    if (!bookmark) {
+      return response.notFound({ error: 'not_found', message: 'Bookmark not found' })
+    }
+    bookmark.enrichmentStatus = 'pending'
+    bookmark.enrichmentError = null
+    bookmark.enrichmentFailureReason = null
+    await bookmark.save()
+    await enrichmentQueue.dispatch(bookmark.id)
+    return response.accepted({ id: bookmark.id })
+  }
+
   async destroy({ params, response }: HttpContext) {
     const bookmark = await Bookmark.find(params.id)
     if (!bookmark) {
@@ -60,4 +140,47 @@ export default class BookmarksController {
     await bookmark.delete()
     return response.noContent()
   }
+}
+
+export function serializeBookmarkRow(r: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: r.id,
+    url: r.url,
+    urlHash: r.url_hash,
+    type: r.type,
+    title: r.title,
+    description: r.description,
+    tags: parseTags(r.tags),
+    ogImage: r.og_image,
+    embedData: r.embed_data,
+    enrichmentStatus: r.enrichment_status,
+    enrichmentError: r.enrichment_error,
+    enrichmentFailureReason: r.enrichment_failure_reason,
+    enrichmentAttempts: r.enrichment_attempts,
+    enrichedAt: toIso(r.enriched_at),
+    embeddingSourceText: r.embedding_source_text,
+    savedAt: toIso(r.saved_at),
+    savedCount: r.saved_count,
+    lastSavedAt: toIso(r.last_saved_at),
+    savedFrom: parseTags(r.saved_from),
+  }
+}
+
+function parseTags(v: unknown): string[] {
+  if (Array.isArray(v)) return v as string[]
+  if (typeof v === 'string') {
+    try {
+      const parsed = JSON.parse(v)
+      return Array.isArray(parsed) ? parsed : []
+    } catch {
+      return []
+    }
+  }
+  return []
+}
+
+function toIso(v: unknown): string | null {
+  if (v == null) return null
+  if (v instanceof Date) return v.toISOString()
+  return String(v)
 }

--- a/apps/api/app/controllers/search_controller.ts
+++ b/apps/api/app/controllers/search_controller.ts
@@ -1,0 +1,37 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import app from '@adonisjs/core/services/app'
+import vine from '@vinejs/vine'
+
+import { embedBookmarkSource } from '#services/embed_bookmark_source'
+import EmbeddingProvider from '#services/embedding_provider'
+import { searchBookmarks } from '#services/search_bookmarks'
+
+const searchValidator = vine.compile(
+  vine.object({
+    query: vine.string().minLength(1),
+    limit: vine.number().positive().optional(),
+    minScore: vine.number().min(0).max(1).optional(),
+    type: vine.enum(['tweet', 'youtube', 'article', 'image', 'pdf', 'other'] as const).optional(),
+    tags: vine.array(vine.string()).optional(),
+  })
+)
+
+export default class SearchController {
+  async handle({ request }: HttpContext) {
+    const payload = await request.validateUsing(searchValidator)
+
+    const provider = await app.container.make(EmbeddingProvider)
+    const model = await provider.getModel()
+    const queryEmbedding = await embedBookmarkSource({ sourceText: payload.query, model })
+
+    const results = await searchBookmarks({
+      queryEmbedding,
+      limit: payload.limit ?? 10,
+      minScore: payload.minScore ?? 0.4,
+      type: payload.type,
+      tags: payload.tags,
+    })
+
+    return { results }
+  }
+}

--- a/apps/api/app/controllers/tags_controller.ts
+++ b/apps/api/app/controllers/tags_controller.ts
@@ -1,0 +1,28 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import db from '@adonisjs/lucid/services/db'
+import vine from '@vinejs/vine'
+
+const tagsValidator = vine.compile(
+  vine.object({
+    minCount: vine.number().positive().optional(),
+  })
+)
+
+export default class TagsController {
+  async index({ request }: HttpContext) {
+    const q = await tagsValidator.validate(request.qs())
+    const minCount = q.minCount ?? 1
+
+    const result = await db.rawQuery(
+      `SELECT tag, COUNT(*)::int AS count
+       FROM bookmarks, jsonb_array_elements_text(tags) AS tag
+       WHERE enrichment_status IN ('done', 'degraded')
+       GROUP BY tag
+       HAVING COUNT(*) >= ?
+       ORDER BY count DESC, tag ASC`,
+      [minCount]
+    )
+    const rows: Array<{ tag: string; count: number }> = result.rows ?? result
+    return { results: rows }
+  }
+}

--- a/apps/api/app/services/search_bookmarks.ts
+++ b/apps/api/app/services/search_bookmarks.ts
@@ -1,0 +1,77 @@
+import db from '@adonisjs/lucid/services/db'
+import type { BookmarkType } from '@stashit/shared'
+
+export interface SearchBookmarksInput {
+  queryEmbedding: number[]
+  limit: number
+  minScore: number
+  type?: BookmarkType
+  tags?: string[]
+}
+
+export interface SearchHit {
+  id: string
+  url: string
+  title: string
+  description: string
+  tags: string[]
+  type: BookmarkType
+  score: number
+  enrichmentStatus: string
+  savedAt: string
+}
+
+export async function searchBookmarks(input: SearchBookmarksInput): Promise<SearchHit[]> {
+  const { queryEmbedding, limit, minScore, type, tags } = input
+  const literal = `[${queryEmbedding.join(',')}]`
+
+  const params: unknown[] = [literal]
+  const wheres: string[] = [`enrichment_status IN ('done', 'degraded')`, `embedding IS NOT NULL`]
+
+  if (type) {
+    params.push(type)
+    wheres.push(`type = ?`)
+  }
+
+  if (tags && tags.length > 0) {
+    params.push(tags)
+    wheres.push(
+      `EXISTS (SELECT 1 FROM jsonb_array_elements_text(tags) AS t(name) WHERE t.name = ANY(?))`
+    )
+  }
+
+  params.push(limit)
+
+  const sql = `
+    SELECT id, url, title, description, tags, type, enrichment_status,
+           saved_at, 1 - (embedding <=> ?::vector) AS score
+    FROM bookmarks
+    WHERE ${wheres.join(' AND ')}
+    ORDER BY embedding <=> '${literal.replace(/'/g, "''")}'::vector ASC
+    LIMIT ?
+  `
+
+  const result = await db.rawQuery(sql, params)
+  const rows: Array<Record<string, unknown>> = result.rows ?? result
+
+  return rows
+    .map((r) => ({
+      id: String(r.id),
+      url: String(r.url),
+      title: String(r.title),
+      description: String(r.description),
+      tags: Array.isArray(r.tags) ? (r.tags as string[]) : JSON.parse(String(r.tags ?? '[]')),
+      type: r.type as BookmarkType,
+      score: clampScore(Number(r.score)),
+      enrichmentStatus: String(r.enrichment_status),
+      savedAt: r.saved_at instanceof Date ? (r.saved_at as Date).toISOString() : String(r.saved_at),
+    }))
+    .filter((hit) => hit.score >= minScore)
+}
+
+function clampScore(s: number): number {
+  if (Number.isNaN(s)) return 0
+  if (s < 0) return 0
+  if (s > 1) return 1
+  return s
+}

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -3,12 +3,19 @@ import router from '@adonisjs/core/services/router'
 import { middleware } from '#start/kernel'
 
 const BookmarksController = () => import('#controllers/bookmarks_controller')
+const SearchController = () => import('#controllers/search_controller')
+const TagsController = () => import('#controllers/tags_controller')
 
 router.get('/', () => ({ ok: true }))
 
 router
   .group(() => {
+    router.post('/search', [SearchController, 'handle'])
+    router.get('/tags', [TagsController, 'index'])
     router.post('/bookmarks', [BookmarksController, 'store'])
+    router.get('/bookmarks', [BookmarksController, 'index'])
+    router.get('/bookmarks/failed', [BookmarksController, 'failed'])
+    router.post('/bookmarks/:id/refresh', [BookmarksController, 'refresh'])
     router.get('/bookmarks/:id', [BookmarksController, 'show'])
     router.delete('/bookmarks/:id', [BookmarksController, 'destroy'])
   })

--- a/apps/api/tests/functional/list_bookmarks.spec.ts
+++ b/apps/api/tests/functional/list_bookmarks.spec.ts
@@ -1,0 +1,74 @@
+import { test } from '@japa/runner'
+
+import { authHeader } from '#tests/helpers/api_key'
+import { seedBookmark } from '#tests/helpers/seed_bookmark'
+
+test.group('GET /bookmarks (list)', (group) => {
+  let auth: { Authorization: string }
+  group.each.setup(async () => {
+    auth = await authHeader()
+  })
+
+  test('returns done+degraded ordered by savedAt DESC, excludes failed/pending/enriching', async ({
+    client,
+    assert,
+  }) => {
+    const old = new Date(Date.now() - 60_000)
+    const newer = new Date()
+    const idOld = await seedBookmark({
+      url: 'https://old.example.com/a',
+      enrichmentStatus: 'done',
+      savedAt: old,
+    })
+    const idNew = await seedBookmark({
+      url: 'https://new.example.com/a',
+      enrichmentStatus: 'degraded',
+      savedAt: newer,
+    })
+    await seedBookmark({ url: 'https://failed.example.com/a', enrichmentStatus: 'failed' })
+    await seedBookmark({ url: 'https://pending.example.com/a', enrichmentStatus: 'pending' })
+    await seedBookmark({ url: 'https://enriching.example.com/a', enrichmentStatus: 'enriching' })
+
+    const res = await client.get('/bookmarks').headers(auth)
+    res.assertStatus(200)
+    const body = res.body() as { results: Array<{ id: string }> }
+    assert.deepEqual(
+      body.results.map((b) => b.id),
+      [idNew, idOld]
+    )
+  })
+
+  test('respects limit and offset', async ({ client, assert }) => {
+    for (let i = 0; i < 4; i++) {
+      await seedBookmark({
+        url: `https://p.example.com/${i}`,
+        savedAt: new Date(Date.now() - (10 - i) * 1000),
+      })
+    }
+
+    const res = await client.get('/bookmarks?limit=2&offset=1').headers(auth)
+    res.assertStatus(200)
+    const body = res.body() as { results: unknown[] }
+    assert.equal(body.results.length, 2)
+  })
+
+  test('filters by tag', async ({ client, assert }) => {
+    const idMl = await seedBookmark({ url: 'https://t1.example.com/a', tags: ['ml', 'video'] })
+    await seedBookmark({ url: 'https://t2.example.com/a', tags: ['cooking'] })
+
+    const res = await client.get('/bookmarks?tag=ml').headers(auth)
+    res.assertStatus(200)
+    const ids = (res.body() as { results: Array<{ id: string }> }).results.map((b) => b.id)
+    assert.deepEqual(ids, [idMl])
+  })
+
+  test('filters by type', async ({ client, assert }) => {
+    const idArticle = await seedBookmark({ url: 'https://a.example.com', type: 'article' })
+    await seedBookmark({ url: 'https://v.example.com', type: 'youtube' })
+
+    const res = await client.get('/bookmarks?type=article').headers(auth)
+    res.assertStatus(200)
+    const ids = (res.body() as { results: Array<{ id: string }> }).results.map((b) => b.id)
+    assert.deepEqual(ids, [idArticle])
+  })
+})

--- a/apps/api/tests/functional/list_failed.spec.ts
+++ b/apps/api/tests/functional/list_failed.spec.ts
@@ -1,0 +1,43 @@
+import { test } from '@japa/runner'
+
+import { authHeader } from '#tests/helpers/api_key'
+import { seedBookmark } from '#tests/helpers/seed_bookmark'
+
+test.group('GET /bookmarks/failed', (group) => {
+  let auth: { Authorization: string }
+  group.each.setup(async () => {
+    auth = await authHeader()
+  })
+
+  test('returns only failed bookmarks', async ({ client, assert }) => {
+    const idFailed = await seedBookmark({
+      url: 'https://failed.example.com/a',
+      enrichmentStatus: 'failed',
+    })
+    await seedBookmark({ url: 'https://done.example.com/a', enrichmentStatus: 'done' })
+    await seedBookmark({ url: 'https://degraded.example.com/a', enrichmentStatus: 'degraded' })
+
+    const res = await client.get('/bookmarks/failed').headers(auth)
+    res.assertStatus(200)
+    const ids = (res.body() as { results: Array<{ id: string }> }).results.map((b) => b.id)
+    assert.deepEqual(ids, [idFailed])
+  })
+
+  test('filters failed by type', async ({ client, assert }) => {
+    const idArticle = await seedBookmark({
+      url: 'https://f1.example.com',
+      type: 'article',
+      enrichmentStatus: 'failed',
+    })
+    await seedBookmark({
+      url: 'https://f2.example.com',
+      type: 'youtube',
+      enrichmentStatus: 'failed',
+    })
+
+    const res = await client.get('/bookmarks/failed?type=article').headers(auth)
+    res.assertStatus(200)
+    const ids = (res.body() as { results: Array<{ id: string }> }).results.map((b) => b.id)
+    assert.deepEqual(ids, [idArticle])
+  })
+})

--- a/apps/api/tests/functional/refresh_bookmark.spec.ts
+++ b/apps/api/tests/functional/refresh_bookmark.spec.ts
@@ -1,0 +1,67 @@
+import app from '@adonisjs/core/services/app'
+import { test } from '@japa/runner'
+
+import EmbeddingProvider from '#services/embedding_provider'
+import enrichmentQueue from '#services/enrichment_queue'
+import LlmProvider from '#services/llm_provider'
+import { authHeader } from '#tests/helpers/api_key'
+import { mockEmbeddingReturning } from '#tests/helpers/mock_embedding'
+import { mockModelReturning } from '#tests/helpers/mock_llm'
+import { seedBookmark } from '#tests/helpers/seed_bookmark'
+
+test.group('POST /bookmarks/:id/refresh', (group) => {
+  let auth: { Authorization: string }
+  group.each.setup(async () => {
+    auth = await authHeader()
+  })
+  group.each.teardown(() => {
+    app.container.restoreAll()
+  })
+
+  test('re-enqueues enrichment and lands the bookmark back to done', async ({ client, assert }) => {
+    const id = await seedBookmark({
+      url: 'https://refresh.example.com/a',
+      title: 'Old title',
+      enrichmentStatus: 'done',
+    })
+
+    app.container.swap(
+      LlmProvider,
+      () =>
+        ({
+          getModel: async () =>
+            mockModelReturning({
+              title: 'New title',
+              description: 'New desc',
+              tags: ['fresh'],
+              type: 'article',
+            }),
+        }) as unknown as LlmProvider
+    )
+    app.container.swap(
+      EmbeddingProvider,
+      () =>
+        ({
+          getModel: async () => mockEmbeddingReturning(new Array(1536).fill(0.01)),
+        }) as unknown as EmbeddingProvider
+    )
+
+    const res = await client.post(`/bookmarks/${id}/refresh`).headers(auth)
+    res.assertStatus(202)
+
+    await enrichmentQueue.flush()
+
+    const after = await client.get(`/bookmarks/${id}`).headers(auth)
+    after.assertStatus(200)
+    const body = after.body()
+    assert.equal(body.title, 'New title')
+    assert.equal(body.enrichmentStatus, 'done')
+  })
+
+  test('returns 404 for unknown bookmark', async ({ client }) => {
+    const res = await client
+      .post('/bookmarks/00000000-0000-0000-0000-000000000000/refresh')
+      .headers(auth)
+    res.assertStatus(404)
+  })
+})

--- a/apps/api/tests/functional/search.spec.ts
+++ b/apps/api/tests/functional/search.spec.ts
@@ -1,0 +1,183 @@
+import app from '@adonisjs/core/services/app'
+import { test } from '@japa/runner'
+
+import EmbeddingProvider from '#services/embedding_provider'
+import { authHeader } from '#tests/helpers/api_key'
+import { mockEmbeddingReturning } from '#tests/helpers/mock_embedding'
+import { seedBookmark, unitVector } from '#tests/helpers/seed_bookmark'
+
+function mockEmbedding(vector: number[]): EmbeddingProvider {
+  return {
+    getModel: async () => mockEmbeddingReturning(vector),
+  } as unknown as EmbeddingProvider
+}
+
+test.group('POST /search', (group) => {
+  let auth: { Authorization: string }
+  group.each.setup(async () => {
+    auth = await authHeader()
+  })
+  group.each.teardown(() => {
+    app.container.restoreAll()
+  })
+
+  test('returns bookmarks ordered by cosine similarity desc with score', async ({
+    client,
+    assert,
+  }) => {
+    const idClose = await seedBookmark({
+      url: 'https://close.example.com/a',
+      title: 'Close match',
+      embedding: unitVector(0),
+    })
+    const idFar = await seedBookmark({
+      url: 'https://far.example.com/b',
+      title: 'Orthogonal',
+      embedding: unitVector(100),
+    })
+
+    app.container.swap(EmbeddingProvider, () => mockEmbedding(unitVector(0)))
+
+    const res = await client.post('/search').headers(auth).json({ query: 'anything' })
+    res.assertStatus(200)
+
+    const body = res.body() as { results: Array<{ id: string; score: number }> }
+    assert.isArray(body.results)
+    assert.isAtLeast(body.results.length, 1)
+    assert.equal(body.results[0].id, idClose)
+    assert.closeTo(body.results[0].score, 1, 0.001)
+
+    const farResult = body.results.find((r) => r.id === idFar)
+    if (farResult) {
+      assert.isBelow(farResult.score, body.results[0].score)
+    }
+  })
+
+  test('excludes failed, pending, enriching from results', async ({ client, assert }) => {
+    const idDone = await seedBookmark({
+      url: 'https://done.example.com/a',
+      embedding: unitVector(0),
+      enrichmentStatus: 'done',
+    })
+    await seedBookmark({
+      url: 'https://failed.example.com/a',
+      embedding: unitVector(0),
+      enrichmentStatus: 'failed',
+    })
+    await seedBookmark({
+      url: 'https://pending.example.com/a',
+      embedding: unitVector(0),
+      enrichmentStatus: 'pending',
+    })
+    await seedBookmark({
+      url: 'https://enriching.example.com/a',
+      embedding: unitVector(0),
+      enrichmentStatus: 'enriching',
+    })
+    const idDegraded = await seedBookmark({
+      url: 'https://degraded.example.com/a',
+      embedding: unitVector(0),
+      enrichmentStatus: 'degraded',
+    })
+
+    app.container.swap(EmbeddingProvider, () => mockEmbedding(unitVector(0)))
+
+    const res = await client.post('/search').headers(auth).json({ query: 'q', minScore: 0 })
+    res.assertStatus(200)
+
+    const ids = (res.body() as { results: Array<{ id: string }> }).results.map((r) => r.id)
+    assert.includeMembers(ids, [idDone, idDegraded])
+    assert.equal(ids.length, 2)
+  })
+
+  test('filters by type', async ({ client, assert }) => {
+    const idArticle = await seedBookmark({
+      url: 'https://article.example.com/a',
+      type: 'article',
+      embedding: unitVector(0),
+    })
+    await seedBookmark({
+      url: 'https://video.example.com/a',
+      type: 'youtube',
+      embedding: unitVector(0),
+    })
+
+    app.container.swap(EmbeddingProvider, () => mockEmbedding(unitVector(0)))
+
+    const res = await client
+      .post('/search')
+      .headers(auth)
+      .json({ query: 'q', type: 'article', minScore: 0 })
+    res.assertStatus(200)
+
+    const ids = (res.body() as { results: Array<{ id: string }> }).results.map((r) => r.id)
+    assert.deepEqual(ids, [idArticle])
+  })
+
+  test('filters by tags (OR semantics)', async ({ client, assert }) => {
+    const idMl = await seedBookmark({
+      url: 'https://ml.example.com/a',
+      tags: ['ml'],
+      embedding: unitVector(0),
+    })
+    const idVideo = await seedBookmark({
+      url: 'https://vid.example.com/a',
+      tags: ['video'],
+      embedding: unitVector(0),
+    })
+    await seedBookmark({
+      url: 'https://other.example.com/a',
+      tags: ['cooking'],
+      embedding: unitVector(0),
+    })
+
+    app.container.swap(EmbeddingProvider, () => mockEmbedding(unitVector(0)))
+
+    const res = await client
+      .post('/search')
+      .headers(auth)
+      .json({ query: 'q', tags: ['ml', 'video'], minScore: 0 })
+    res.assertStatus(200)
+
+    const ids = (res.body() as { results: Array<{ id: string }> }).results.map((r) => r.id).sort()
+    assert.deepEqual(ids, [idMl, idVideo].sort())
+  })
+
+  test('respects minScore', async ({ client, assert }) => {
+    await seedBookmark({
+      url: 'https://orth.example.com/a',
+      embedding: unitVector(100),
+    })
+    const idClose = await seedBookmark({
+      url: 'https://close2.example.com/a',
+      embedding: unitVector(0),
+    })
+
+    app.container.swap(EmbeddingProvider, () => mockEmbedding(unitVector(0)))
+
+    const res = await client.post('/search').headers(auth).json({ query: 'q', minScore: 0.5 })
+    res.assertStatus(200)
+
+    const results = (res.body() as { results: Array<{ id: string; score: number }> }).results
+    assert.equal(results.length, 1)
+    assert.equal(results[0].id, idClose)
+  })
+
+  test('respects limit', async ({ client, assert }) => {
+    for (let i = 0; i < 5; i++) {
+      await seedBookmark({
+        url: `https://lim.example.com/${i}`,
+        embedding: unitVector(0),
+      })
+    }
+    app.container.swap(EmbeddingProvider, () => mockEmbedding(unitVector(0)))
+
+    const res = await client
+      .post('/search')
+      .headers(auth)
+      .json({ query: 'q', limit: 2, minScore: 0 })
+    res.assertStatus(200)
+    const results = (res.body() as { results: unknown[] }).results
+    assert.equal(results.length, 2)
+  })
+})

--- a/apps/api/tests/functional/tags.spec.ts
+++ b/apps/api/tests/functional/tags.spec.ts
@@ -1,0 +1,48 @@
+import { test } from '@japa/runner'
+
+import { authHeader } from '#tests/helpers/api_key'
+import { seedBookmark } from '#tests/helpers/seed_bookmark'
+
+test.group('GET /tags', (group) => {
+  let auth: { Authorization: string }
+  group.each.setup(async () => {
+    auth = await authHeader()
+  })
+
+  test('returns [{tag,count}] desc with default minCount=1', async ({ client, assert }) => {
+    await seedBookmark({ url: 'https://t.example.com/a', tags: ['ml', 'ai'] })
+    await seedBookmark({ url: 'https://t.example.com/b', tags: ['ml'] })
+    await seedBookmark({ url: 'https://t.example.com/c', tags: ['cooking'] })
+    // failed bookmark — its tags must NOT count
+    await seedBookmark({
+      url: 'https://t.example.com/d',
+      tags: ['ml', 'ml-failed'],
+      enrichmentStatus: 'failed',
+    })
+
+    const res = await client.get('/tags').headers(auth)
+    res.assertStatus(200)
+    const body = res.body() as { results: Array<{ tag: string; count: number }> }
+    const map = Object.fromEntries(body.results.map((r) => [r.tag, r.count]))
+    assert.equal(map.ml, 2)
+    assert.equal(map.ai, 1)
+    assert.equal(map.cooking, 1)
+    assert.notProperty(map, 'ml-failed')
+
+    // ordered by count desc
+    const counts = body.results.map((r) => r.count)
+    const sorted = [...counts].sort((a, b) => b - a)
+    assert.deepEqual(counts, sorted)
+  })
+
+  test('respects minCount filter', async ({ client, assert }) => {
+    await seedBookmark({ url: 'https://t.example.com/a', tags: ['ml', 'ai'] })
+    await seedBookmark({ url: 'https://t.example.com/b', tags: ['ml'] })
+
+    const res = await client.get('/tags?minCount=2').headers(auth)
+    res.assertStatus(200)
+    const body = res.body() as { results: Array<{ tag: string; count: number }> }
+    assert.equal(body.results.length, 1)
+    assert.equal(body.results[0].tag, 'ml')
+  })
+})

--- a/apps/api/tests/helpers/seed_bookmark.ts
+++ b/apps/api/tests/helpers/seed_bookmark.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'node:crypto'
+
+import db from '@adonisjs/lucid/services/db'
+import { hashUrl } from '@stashit/shared'
+
+export interface SeedBookmarkInput {
+  url: string
+  title?: string
+  description?: string
+  tags?: string[]
+  type?: 'tweet' | 'youtube' | 'article' | 'image' | 'pdf' | 'other'
+  enrichmentStatus?: 'pending' | 'enriching' | 'done' | 'degraded' | 'failed'
+  embedding?: number[] | null
+  savedAt?: Date
+}
+
+export async function seedBookmark(input: SeedBookmarkInput): Promise<string> {
+  const id = randomUUID()
+  const url = input.url
+  const urlHash = hashUrl(url)
+  const tags = input.tags ?? []
+  const status = input.enrichmentStatus ?? 'done'
+  const savedAt = input.savedAt ?? new Date()
+  const embeddingLiteral = input.embedding ? `[${input.embedding.join(',')}]` : null
+
+  await db.rawQuery(
+    `INSERT INTO bookmarks (
+       id, url, url_hash, type, title, description, tags,
+       enrichment_status, enrichment_attempts,
+       embedding, saved_at, last_saved_at, saved_count, saved_from
+     ) VALUES (?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ${embeddingLiteral === null ? 'NULL' : '?::vector'}, ?, ?, ?, ?::jsonb)`,
+    [
+      id,
+      url,
+      urlHash,
+      input.type ?? 'article',
+      input.title ?? '',
+      input.description ?? '',
+      JSON.stringify(tags),
+      status,
+      0,
+      ...(embeddingLiteral === null ? [] : [embeddingLiteral]),
+      savedAt,
+      savedAt,
+      1,
+      JSON.stringify([]),
+    ]
+  )
+
+  return id
+}
+
+/**
+ * Build a 1536-dim unit vector with most weight in one slot. Deterministic
+ * fixtures for cosine ordering: vectors with the same hot slot are similar,
+ * different hot slots are orthogonal.
+ */
+export function unitVector(hotIndex: number, dim = 1536): number[] {
+  const v = new Array(dim).fill(0)
+  v[hotIndex] = 1
+  return v
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -85,6 +85,116 @@ Hard-delete a bookmark.
 - `404 Not Found` — `{ "error": "not_found", "message": "Bookmark not found" }`.
 - `401 Unauthorized` — auth.
 
+---
+
+### `GET /bookmarks`
+
+List recent bookmarks. Excludes `failed`, `pending`, `enriching` — only `done` and `degraded` are returned.
+
+**Query**
+
+| Param    | Type                                                        | Default | Notes                          |
+| -------- | ----------------------------------------------------------- | ------- | ------------------------------ |
+| `limit`  | int 1-200                                                   | 50      |                                |
+| `offset` | int ≥0                                                      | 0       |                                |
+| `type`   | enum `tweet \| youtube \| article \| image \| pdf \| other` | —       | optional filter                |
+| `tag`    | string                                                      | —       | exact tag match (single value) |
+
+**Response 200**
+
+```json
+{ "results": [Bookmark, ...] }
+```
+
+Ordered by `savedAt DESC`.
+
+---
+
+### `GET /bookmarks/failed`
+
+List bookmarks whose enrichment ended in `failed`. Separate path so failures never leak into the default listing.
+
+**Query**: `limit`, `offset`, `type` — same as `GET /bookmarks`.
+
+---
+
+### `POST /bookmarks/:id/refresh`
+
+Re-enqueue the enrichment pipeline for a bookmark. Resets `enrichmentStatus` to `pending` and clears the previous error.
+
+**Responses**
+
+- `202 Accepted` — `{ "id": "<uuid>" }`. The job is queued; poll `GET /bookmarks/:id` for completion.
+- `404 Not Found`.
+
+---
+
+### `POST /search`
+
+Semantic similarity search over `done` + `degraded` bookmarks. Filters are applied **before** the vector top-K so `type` / `tags` queries always return up to `limit` results when enough exist.
+
+**Body**
+
+```json
+{
+  "query": "kubernetes orchestration",
+  "limit": 10,
+  "minScore": 0.4,
+  "type": "article",
+  "tags": ["devops", "infra"]
+}
+```
+
+| Field      | Type               | Default | Notes                          |
+| ---------- | ------------------ | ------- | ------------------------------ |
+| `query`    | string (1+ chars)  | —       | required                       |
+| `limit`    | int >0             | 10      |                                |
+| `minScore` | float 0–1          | 0.4     | raw cosine similarity cut      |
+| `type`     | bookmark type enum | —       | optional                       |
+| `tags`     | string[]           | —       | OR semantics (any tag matches) |
+
+**Response 200**
+
+```json
+{
+  "results": [
+    {
+      "id": "<uuid>",
+      "url": "https://...",
+      "title": "...",
+      "description": "...",
+      "tags": [...],
+      "type": "article",
+      "score": 0.87,
+      "enrichmentStatus": "done",
+      "savedAt": "2026-01-12T10:21:09.000Z"
+    }
+  ]
+}
+```
+
+`score` is raw cosine similarity (`1 - cosine_distance`), clamped to `[0, 1]`. Higher = closer.
+
+---
+
+### `GET /tags`
+
+List distinct tags with usage counts (over `done` + `degraded` bookmarks only).
+
+**Query**
+
+| Param      | Type | Default | Notes              |
+| ---------- | ---- | ------- | ------------------ |
+| `minCount` | int  | 1       | filter sparse tags |
+
+**Response 200**
+
+```json
+{ "results": [{ "tag": "ml", "count": 12 }, ...] }
+```
+
+Ordered by count desc, then alphabetical.
+
 ## Bookmark schema
 
 ```ts
@@ -131,7 +241,6 @@ None in v1. Single-user expected. Add a reverse proxy (Caddy, Traefik, nginx) if
 
 ## Roadmap
 
-- `POST /search` — semantic + keyword search with pgvector
-- `GET /bookmarks` — paginated list, filter by tags / type / status
 - `PATCH /bookmarks/:id` — edit title, tags, description
+- Hybrid search (BM25 + vector) — v1.x candidate
 - OpenAPI spec auto-generation


### PR DESCRIPTION
Closes #11.

## Summary
Read surface for the API powering CLI / MCP / extension: semantic search via pgvector, paginated listings with filters, tag aggregation, failed-bookmark inspection, and on-demand refresh.

## Changes
- `apps/api/app/services/search_bookmarks.ts` — pgvector cosine search with pre-top-K filtering (type, tags OR, min_score, limit)
- `apps/api/app/controllers/search_controller.ts` — `POST /search`, embeds query via `EmbeddingProvider`
- `apps/api/app/controllers/tags_controller.ts` — `GET /tags?minCount=`, ordered by count desc
- `apps/api/app/controllers/bookmarks_controller.ts` — adds `index`, `failed`, `refresh` actions + raw-row serializer
- `apps/api/start/routes.ts` — registers new routes; `/bookmarks/failed` registered before `/bookmarks/:id` to avoid param shadowing
- `apps/api/tests/helpers/seed_bookmark.ts` — direct-insert helper with deterministic 1536-dim embeddings
- `apps/api/tests/functional/{search,list_bookmarks,tags,list_failed,refresh_bookmark}.spec.ts` — 16 new functional tests (60/60 total green)
- `docs/API.md` — documents all new endpoints, drops them from the roadmap

## Test plan
- [x] CI passes
- [x] Manual smoke: `POST /search` returns ordered results with `score` between 0 and 1