### PR TITLE
feat(api): server-side fetch via Jina + oEmbed for tweet/youtube

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,8 @@ STASHIT_LLM_API_KEY=
 STASHIT_EMBEDDING_PROVIDER=openai
 STASHIT_EMBEDDING_MODEL=text-embedding-3-small
 STASHIT_EMBEDDING_API_KEY=
+
+# ─── Fetch provider (server-side extraction) ───────────────────────────────────
+# Provider one of: jina (default — r.jina.ai, free, no key required for low rate)
+STASHIT_FETCH_PROVIDER=jina
+STASHIT_FETCH_API_KEY=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -23,3 +23,9 @@ STASHIT_LLM_API_KEY=
 STASHIT_EMBEDDING_PROVIDER=openai
 STASHIT_EMBEDDING_MODEL=text-embedding-3-small
 STASHIT_EMBEDDING_API_KEY=
+
+# Fetch (server-side content extraction when client doesn't pass content)
+# Provider one of: jina (default; r.jina.ai, free, no key required for low rate)
+STASHIT_FETCH_PROVIDER=jina
+# Optional: Jina API key for higher rate limits (200+ req/min vs 20 anon).
+STASHIT_FETCH_API_KEY=

--- a/apps/api/app/jobs/enrich_bookmark_job.ts
+++ b/apps/api/app/jobs/enrich_bookmark_job.ts
@@ -1,6 +1,6 @@
 import app from '@adonisjs/core/services/app'
 import db from '@adonisjs/lucid/services/db'
-import type { EnrichmentFailureReason } from '@stashit/shared'
+import { detectType, type EnrichmentFailureReason } from '@stashit/shared'
 import { DateTime } from 'luxon'
 
 import Bookmark from '#models/bookmark'
@@ -8,18 +8,20 @@ import { composeEmbeddingSource } from '#services/compose_embedding_source'
 import { embedBookmarkSource } from '#services/embed_bookmark_source'
 import EmbeddingProvider from '#services/embedding_provider'
 import { enrichBookmark } from '#services/enrich_bookmark'
+import FetchProvider, { type FetchOutcome } from '#services/fetch_provider'
 import LlmProvider from '#services/llm_provider'
 
 class StageError extends Error {
   constructor(
-    public stage: 'llm' | 'embedding',
-    message: string
+    public stage: 'llm' | 'embedding' | 'fetch',
+    message: string,
+    public reason?: EnrichmentFailureReason
   ) {
     super(message)
   }
 }
 
-const FAILURE_REASON: Record<StageError['stage'], EnrichmentFailureReason> = {
+const FAILURE_REASON: Record<'llm' | 'embedding', EnrichmentFailureReason> = {
   llm: 'llm_provider_error',
   embedding: 'embedding_provider_error',
 }
@@ -34,7 +36,27 @@ export default class EnrichBookmarkJob {
     await bookmark.save()
 
     try {
-      const sourceText = (content && content.trim()) || bookmark.title || bookmark.url
+      const detectedType = detectType(bookmark.url)
+      const trimmed = content?.trim()
+
+      const fetched: FetchOutcome | null = trimmed
+        ? null
+        : await runFetch(bookmark.url, detectedType)
+
+      if (fetched?.kind === 'dead') {
+        throw new StageError('fetch', `URL is dead: ${fetched.reason}`, 'url_dead')
+      }
+
+      const sourceText = pickSourceText({
+        clientContent: trimmed,
+        fetched,
+        fallback: bookmark.title || bookmark.url,
+      })
+
+      if (fetched?.kind === 'success') {
+        if (fetched.ogImage) bookmark.ogImage = fetched.ogImage
+        if (fetched.embedData !== undefined) bookmark.embedData = fetched.embedData
+      }
 
       const enrichment = await runLlm(sourceText)
 
@@ -55,7 +77,7 @@ export default class EnrichBookmarkJob {
       await persistEmbedding(bookmark.id, vector, embeddingSourceText)
 
       bookmark.embeddingSourceText = embeddingSourceText
-      bookmark.enrichmentStatus = 'done'
+      bookmark.enrichmentStatus = fetched?.kind === 'meta_only' ? 'degraded' : 'done'
       bookmark.enrichmentError = null
       bookmark.enrichmentFailureReason = null
       bookmark.enrichedAt = DateTime.utc()
@@ -63,10 +85,44 @@ export default class EnrichBookmarkJob {
     } catch (err) {
       bookmark.enrichmentStatus = 'failed'
       bookmark.enrichmentError = err instanceof Error ? err.message : String(err)
-      bookmark.enrichmentFailureReason =
-        err instanceof StageError ? FAILURE_REASON[err.stage] : 'llm_provider_error'
+      bookmark.enrichmentFailureReason = pickFailureReason(err)
       await bookmark.save()
     }
+  }
+}
+
+function pickFailureReason(err: unknown): EnrichmentFailureReason {
+  if (err instanceof StageError) {
+    if (err.reason) return err.reason
+    if (err.stage === 'llm' || err.stage === 'embedding') return FAILURE_REASON[err.stage]
+  }
+  return 'unknown'
+}
+
+function pickSourceText(opts: {
+  clientContent?: string
+  fetched: FetchOutcome | null
+  fallback: string
+}): string {
+  if (opts.clientContent) return opts.clientContent
+  if (opts.fetched?.kind === 'success') return opts.fetched.content
+  if (opts.fetched?.kind === 'meta_only') {
+    const parts = [opts.fetched.ogTitle, opts.fetched.ogDescription, opts.fallback].filter(Boolean)
+    return parts.join('\n\n') || opts.fallback
+  }
+  return opts.fallback
+}
+
+async function runFetch(url: string, type: ReturnType<typeof detectType>): Promise<FetchOutcome> {
+  try {
+    const provider = await app.container.make(FetchProvider)
+    return await provider.fetchAndExtract(url, type)
+  } catch (err) {
+    throw new StageError(
+      'fetch',
+      err instanceof Error ? err.message : String(err),
+      'fetch_unavailable'
+    )
   }
 }
 

--- a/apps/api/app/services/embedding_provider.ts
+++ b/apps/api/app/services/embedding_provider.ts
@@ -3,7 +3,7 @@ import type { EmbeddingModel } from 'ai'
 
 import env from '#start/env'
 
-export type SupportedEmbeddingProvider = 'openai'
+export type SupportedEmbeddingProvider = 'openai' | 'openrouter'
 
 export default class EmbeddingProvider {
   async getModel(): Promise<EmbeddingModel> {
@@ -28,6 +28,10 @@ export async function resolveEmbeddingModel(
     case 'openai': {
       const { createOpenAI } = await import('@ai-sdk/openai')
       return createOpenAI({ apiKey }).embedding(modelId)
+    }
+    case 'openrouter': {
+      const { createOpenRouter } = await import('@openrouter/ai-sdk-provider')
+      return createOpenRouter({ apiKey }).textEmbeddingModel(modelId)
     }
   }
 }

--- a/apps/api/app/services/enrich_bookmark.ts
+++ b/apps/api/app/services/enrich_bookmark.ts
@@ -5,10 +5,12 @@ import { normalizeTags } from '#services/tag_normalizer'
 
 const BOOKMARK_TYPES = ['tweet', 'youtube', 'article', 'image', 'pdf', 'other'] as const
 
+// NOTE: no `min/max` constraints on the array — Anthropic's structured output
+// rejects `maxItems` on JSON Schema arrays. We cap downstream in normalizeTags.
 const enrichmentSchema = z.object({
-  title: z.string().min(1).max(300),
-  description: z.string().max(2000),
-  tags: z.array(z.string()).max(12),
+  title: z.string(),
+  description: z.string(),
+  tags: z.array(z.string()),
   type: z.enum(BOOKMARK_TYPES),
 })
 

--- a/apps/api/app/services/fetch_provider.ts
+++ b/apps/api/app/services/fetch_provider.ts
@@ -1,0 +1,126 @@
+import type { BookmarkType } from '@stashit/shared'
+
+import env from '#start/env'
+
+export type FetchOutcome =
+  | {
+      kind: 'success'
+      content: string
+      ogImage?: string
+      embedData?: unknown
+    }
+  | {
+      kind: 'meta_only'
+      ogTitle?: string
+      ogDescription?: string
+      ogImage?: string
+      reason: 'empty' | 'paywall' | 'auth' | 'transient'
+    }
+  | {
+      kind: 'dead'
+      reason: 'url_dead' | 'malformed'
+    }
+
+const MIN_CONTENT_CHARS = 100
+const FETCH_TIMEOUT_MS = 15_000
+
+export default class FetchProvider {
+  async fetchAndExtract(url: string, type: BookmarkType): Promise<FetchOutcome> {
+    if (type === 'tweet') return fetchTweet(url)
+    if (type === 'youtube') return fetchYouTube(url)
+    return fetchViaJina(url)
+  }
+}
+
+async function fetchViaJina(url: string): Promise<FetchOutcome> {
+  const apiKey = env.get('STASHIT_FETCH_API_KEY')
+  const headers: Record<string, string> = {
+    'Accept': 'text/markdown',
+    'User-Agent': 'stashit/1.0',
+  }
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+
+  let res: Response
+  try {
+    res = await fetchWithTimeout(`https://r.jina.ai/${url}`, { headers }, FETCH_TIMEOUT_MS)
+  } catch {
+    return { kind: 'meta_only', reason: 'transient' }
+  }
+
+  if (res.status === 404 || res.status === 410) {
+    return { kind: 'dead', reason: 'url_dead' }
+  }
+  if (res.status === 401 || res.status === 403 || res.status === 451) {
+    return { kind: 'meta_only', reason: 'auth' }
+  }
+  if (!res.ok) {
+    return { kind: 'meta_only', reason: 'transient' }
+  }
+
+  const body = (await res.text()).trim()
+  if (body.length < MIN_CONTENT_CHARS) {
+    return { kind: 'meta_only', reason: 'empty' }
+  }
+
+  return { kind: 'success', content: body }
+}
+
+async function fetchTweet(url: string): Promise<FetchOutcome> {
+  const oembed = `https://publish.twitter.com/oembed?url=${encodeURIComponent(url)}&omit_script=1`
+  try {
+    const res = await fetchWithTimeout(oembed, {}, FETCH_TIMEOUT_MS)
+    if (res.status === 404) return { kind: 'dead', reason: 'url_dead' }
+    if (!res.ok) return { kind: 'meta_only', reason: 'transient' }
+    const data = (await res.json()) as { html?: string; author_name?: string }
+    const content = stripHtml(data.html ?? '')
+    return { kind: 'success', content, embedData: data }
+  } catch {
+    return { kind: 'meta_only', reason: 'transient' }
+  }
+}
+
+async function fetchYouTube(url: string): Promise<FetchOutcome> {
+  const oembed = `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`
+  try {
+    const res = await fetchWithTimeout(oembed, {}, FETCH_TIMEOUT_MS)
+    if (res.status === 404) return { kind: 'dead', reason: 'url_dead' }
+    if (!res.ok) return { kind: 'meta_only', reason: 'transient' }
+    const data = (await res.json()) as {
+      title?: string
+      author_name?: string
+      thumbnail_url?: string
+    }
+    const content = [data.title, data.author_name].filter(Boolean).join(' — ')
+    return {
+      kind: 'success',
+      content,
+      embedData: data,
+      ogImage: data.thumbnail_url,
+    }
+  } catch {
+    return { kind: 'meta_only', reason: 'transient' }
+  }
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...init, signal: ctrl.signal, redirect: 'follow' })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}

--- a/apps/api/app/services/tag_normalizer.ts
+++ b/apps/api/app/services/tag_normalizer.ts
@@ -11,6 +11,8 @@ export function normalizeTag(input: string): string {
   return cleaned.split('-').filter(Boolean).map(singularize).join('-')
 }
 
+const TAG_CAP = 12
+
 export function normalizeTags(tags: readonly string[]): string[] {
   const out: string[] = []
   const seen = new Set<string>()
@@ -19,6 +21,7 @@ export function normalizeTags(tags: readonly string[]): string[] {
     if (!n || seen.has(n)) continue
     seen.add(n)
     out.push(n)
+    if (out.length >= TAG_CAP) break
   }
   return out
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -52,6 +52,7 @@
     "@types/node": "~25.6.0",
     "eslint": "^10.2.0",
     "hot-hook": "^1.0.0",
+    "nock": "^14.0.13",
     "pino-pretty": "^13.1.3",
     "prettier": "^3.8.2",
     "typescript": "~6.0.2",

--- a/apps/api/start/env.ts
+++ b/apps/api/start/env.ts
@@ -25,4 +25,7 @@ export default await Env.create(new URL('../', import.meta.url), {
   STASHIT_EMBEDDING_PROVIDER: Env.schema.enum.optional(['openai'] as const),
   STASHIT_EMBEDDING_MODEL: Env.schema.string.optional(),
   STASHIT_EMBEDDING_API_KEY: Env.schema.string.optional(),
+
+  STASHIT_FETCH_PROVIDER: Env.schema.enum.optional(['jina'] as const),
+  STASHIT_FETCH_API_KEY: Env.schema.string.optional(),
 })

--- a/apps/api/start/env.ts
+++ b/apps/api/start/env.ts
@@ -22,7 +22,7 @@ export default await Env.create(new URL('../', import.meta.url), {
   STASHIT_LLM_MODEL: Env.schema.string.optional(),
   STASHIT_LLM_API_KEY: Env.schema.string.optional(),
 
-  STASHIT_EMBEDDING_PROVIDER: Env.schema.enum.optional(['openai'] as const),
+  STASHIT_EMBEDDING_PROVIDER: Env.schema.enum.optional(['openai', 'openrouter'] as const),
   STASHIT_EMBEDDING_MODEL: Env.schema.string.optional(),
   STASHIT_EMBEDDING_API_KEY: Env.schema.string.optional(),
 

--- a/apps/api/tests/functional/auto_fetch.spec.ts
+++ b/apps/api/tests/functional/auto_fetch.spec.ts
@@ -1,0 +1,142 @@
+import app from '@adonisjs/core/services/app'
+import { test } from '@japa/runner'
+import nock from 'nock'
+
+import EmbeddingProvider from '#services/embedding_provider'
+import enrichmentQueue from '#services/enrichment_queue'
+import LlmProvider from '#services/llm_provider'
+import { authHeader } from '#tests/helpers/api_key'
+import { mockEmbeddingReturning } from '#tests/helpers/mock_embedding'
+import { mockModelReturning } from '#tests/helpers/mock_llm'
+
+function mockLlm(json: object): LlmProvider {
+  return {
+    getModel: async () => mockModelReturning(json),
+  } as unknown as LlmProvider
+}
+
+function mockEmbedding(): EmbeddingProvider {
+  return {
+    getModel: async () => mockEmbeddingReturning(new Array(1536).fill(0.01)),
+  } as unknown as EmbeddingProvider
+}
+
+test.group('Auto-fetch pipeline (E2E)', (group) => {
+  let auth: { Authorization: string }
+  group.each.setup(async () => {
+    auth = await authHeader()
+    nock.disableNetConnect()
+    nock.enableNetConnect((host) => host.includes('127.0.0.1') || host.includes('localhost'))
+  })
+  group.each.teardown(() => {
+    app.container.restoreAll()
+    nock.cleanAll()
+    nock.enableNetConnect()
+  })
+
+  test('POST without content fetches via Jina and lands done', async ({ client, assert }) => {
+    nock('https://r.jina.ai')
+      .get('/https://example.com/post')
+      .reply(
+        200,
+        '# Real Article\n\n' +
+          'Long-form content fetched from Jina Reader, well over the 100-char threshold to qualify as a successful extraction. More body to be sure.'
+      )
+
+    app.container.swap(LlmProvider, () =>
+      mockLlm({
+        title: 'Real Article',
+        description: 'Fetched and enriched.',
+        tags: ['fetch'],
+        type: 'article',
+      })
+    )
+    app.container.swap(EmbeddingProvider, () => mockEmbedding())
+
+    const created = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://example.com/post' })
+    created.assertStatus(201)
+
+    await enrichmentQueue.flush()
+
+    const after = await client.get(`/bookmarks/${created.body().id}`).headers(auth)
+    after.assertStatus(200)
+    const body = after.body()
+    assert.equal(body.enrichmentStatus, 'done')
+    assert.equal(body.title, 'Real Article')
+  })
+
+  test('Jina 404 → bookmark failed with url_dead', async ({ client, assert }) => {
+    nock('https://r.jina.ai').get('/https://gone.example.com/post').reply(404, 'not found')
+
+    app.container.swap(LlmProvider, () =>
+      mockLlm({ title: 't', description: 'd', tags: ['x'], type: 'article' })
+    )
+    app.container.swap(EmbeddingProvider, () => mockEmbedding())
+
+    const created = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://gone.example.com/post' })
+    created.assertStatus(201)
+
+    await enrichmentQueue.flush()
+
+    const after = await client.get(`/bookmarks/${created.body().id}`).headers(auth)
+    const body = after.body()
+    assert.equal(body.enrichmentStatus, 'failed')
+    assert.equal(body.enrichmentFailureReason, 'url_dead')
+  })
+
+  test('Empty Jina response → bookmark degraded (LLM ran on fallback)', async ({
+    client,
+    assert,
+  }) => {
+    nock('https://r.jina.ai').get('/https://thin.example.com/post').reply(200, '   ')
+
+    app.container.swap(LlmProvider, () =>
+      mockLlm({
+        title: 'Thin Article',
+        description: 'Inferred from URL only.',
+        tags: ['unknown'],
+        type: 'article',
+      })
+    )
+    app.container.swap(EmbeddingProvider, () => mockEmbedding())
+
+    const created = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://thin.example.com/post' })
+    created.assertStatus(201)
+
+    await enrichmentQueue.flush()
+
+    const after = await client.get(`/bookmarks/${created.body().id}`).headers(auth)
+    const body = after.body()
+    assert.equal(body.enrichmentStatus, 'degraded')
+    assert.equal(body.title, 'Thin Article')
+  })
+
+  test('Client-provided content skips fetch entirely', async ({ client, assert }) => {
+    // No nock interceptor → if fetch is called, the test will fail because nock blocks the request.
+
+    app.container.swap(LlmProvider, () =>
+      mockLlm({ title: 'Provided', description: 'd', tags: ['x'], type: 'article' })
+    )
+    app.container.swap(EmbeddingProvider, () => mockEmbedding())
+
+    const created = await client.post('/bookmarks').headers(auth).json({
+      url: 'https://shortcut.example.com/post',
+      content: 'Long-form content already extracted by Safari Reader, no fetch needed.',
+    })
+    created.assertStatus(201)
+
+    await enrichmentQueue.flush()
+
+    const after = await client.get(`/bookmarks/${created.body().id}`).headers(auth)
+    assert.equal(after.body().enrichmentStatus, 'done')
+  })
+})

--- a/apps/api/tests/functional/refresh_bookmark.spec.ts
+++ b/apps/api/tests/functional/refresh_bookmark.spec.ts
@@ -3,6 +3,7 @@ import { test } from '@japa/runner'
 
 import EmbeddingProvider from '#services/embedding_provider'
 import enrichmentQueue from '#services/enrichment_queue'
+import FetchProvider from '#services/fetch_provider'
 import LlmProvider from '#services/llm_provider'
 import { authHeader } from '#tests/helpers/api_key'
 import { mockEmbeddingReturning } from '#tests/helpers/mock_embedding'
@@ -44,6 +45,17 @@ test.group('POST /bookmarks/:id/refresh', (group) => {
         ({
           getModel: async () => mockEmbeddingReturning(new Array(1536).fill(0.01)),
         }) as unknown as EmbeddingProvider
+    )
+    app.container.swap(
+      FetchProvider,
+      () =>
+        ({
+          fetchAndExtract: async () => ({
+            kind: 'success' as const,
+            content:
+              'Refetched body content with enough characters to pass the threshold for a successful Jina extraction.',
+          }),
+        }) as unknown as FetchProvider
     )
 
     const res = await client.post(`/bookmarks/${id}/refresh`).headers(auth)

--- a/apps/api/tests/unit/fetch_provider.spec.ts
+++ b/apps/api/tests/unit/fetch_provider.spec.ts
@@ -1,0 +1,98 @@
+import { test } from '@japa/runner'
+import nock from 'nock'
+
+import FetchProvider from '#services/fetch_provider'
+
+test.group('FetchProvider (Jina)', (group) => {
+  group.each.setup(() => {
+    nock.disableNetConnect()
+    return () => {
+      nock.cleanAll()
+      nock.enableNetConnect()
+    }
+  })
+
+  test('article: returns success with markdown content from Jina', async ({ assert }) => {
+    nock('https://r.jina.ai')
+      .get('/https://example.com/post')
+      .reply(
+        200,
+        '# Hello\n\nThis is the article body, well over 100 chars to count as real content.\n\nMore paragraphs here that make the body substantial enough to qualify as a successful extraction.'
+      )
+
+    const provider = new FetchProvider()
+    const outcome = await provider.fetchAndExtract('https://example.com/post', 'article')
+
+    assert.equal(outcome.kind, 'success')
+    if (outcome.kind === 'success') {
+      assert.match(outcome.content, /# Hello/)
+      assert.match(outcome.content, /article body/)
+    }
+  })
+
+  test('article: empty/short Jina response → meta_only', async ({ assert }) => {
+    nock('https://r.jina.ai').get('/https://thin.example.com/p').reply(200, '   ')
+    const provider = new FetchProvider()
+    const outcome = await provider.fetchAndExtract('https://thin.example.com/p', 'article')
+    assert.equal(outcome.kind, 'meta_only')
+    if (outcome.kind === 'meta_only') {
+      assert.equal(outcome.reason, 'empty')
+    }
+  })
+
+  test('article: 404 from Jina → dead with url_dead', async ({ assert }) => {
+    nock('https://r.jina.ai').get('/https://gone.example.com/p').reply(404, 'not found')
+    const provider = new FetchProvider()
+    const outcome = await provider.fetchAndExtract('https://gone.example.com/p', 'article')
+    assert.equal(outcome.kind, 'dead')
+    if (outcome.kind === 'dead') {
+      assert.equal(outcome.reason, 'url_dead')
+    }
+  })
+
+  test('article: 403 → meta_only with reason=auth', async ({ assert }) => {
+    nock('https://r.jina.ai').get('/https://paywall.example.com/p').reply(403, 'forbidden')
+    const provider = new FetchProvider()
+    const outcome = await provider.fetchAndExtract('https://paywall.example.com/p', 'article')
+    assert.equal(outcome.kind, 'meta_only')
+    if (outcome.kind === 'meta_only') {
+      assert.equal(outcome.reason, 'auth')
+    }
+  })
+
+  test('tweet: oEmbed → success with embedData', async ({ assert }) => {
+    const oembedResponse = {
+      url: 'https://x.com/foo/status/1',
+      author_name: 'Foo',
+      html: '<blockquote class="twitter-tweet"><p>Hello world</p></blockquote>',
+      provider_name: 'X',
+    }
+    nock('https://publish.twitter.com').get('/oembed').query(true).reply(200, oembedResponse)
+
+    const provider = new FetchProvider()
+    const outcome = await provider.fetchAndExtract('https://x.com/foo/status/1', 'tweet')
+    assert.equal(outcome.kind, 'success')
+    if (outcome.kind === 'success') {
+      assert.match(outcome.content, /Hello world/)
+      assert.deepEqual(outcome.embedData, oembedResponse)
+    }
+  })
+
+  test('youtube: oEmbed → success with embedData and ogImage thumbnail', async ({ assert }) => {
+    const oembedResponse = {
+      title: 'Some Video',
+      author_name: 'Channel Name',
+      thumbnail_url: 'https://i.ytimg.com/vi/abc/hqdefault.jpg',
+    }
+    nock('https://www.youtube.com').get('/oembed').query(true).reply(200, oembedResponse)
+
+    const provider = new FetchProvider()
+    const outcome = await provider.fetchAndExtract('https://www.youtube.com/watch?v=abc', 'youtube')
+    assert.equal(outcome.kind, 'success')
+    if (outcome.kind === 'success') {
+      assert.include(outcome.content, 'Some Video')
+      assert.equal(outcome.ogImage, 'https://i.ytimg.com/vi/abc/hqdefault.jpg')
+      assert.deepEqual(outcome.embedData, oembedResponse)
+    }
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       hot-hook:
         specifier: ^1.0.0
         version: 1.0.0
+      nock:
+        specifier: ^14.0.13
+        version: 14.0.13
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
@@ -960,6 +963,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@mswjs/interceptors@0.41.6':
+    resolution: {integrity: sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==}
+    engines: {node: '>=18'}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
@@ -975,6 +982,15 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@openrouter/ai-sdk-provider@2.8.1':
     resolution: {integrity: sha512-Y6j3yivgoEUf/kutD/k5GX/mzZfioRFoSx0gbQ+mIOzMaH/vJv1rCkztiuvlLw5xRYQil7oxHUZvmSfXqOx1NQ==}
@@ -2343,6 +2359,9 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -2400,6 +2419,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   jsonschema@1.5.0:
     resolution: {integrity: sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==}
@@ -2628,6 +2650,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  nock@14.0.13:
+    resolution: {integrity: sha512-SCPsQmGVNY8h1rfS3aU0MzOGYY+wKIFukHEsoSIwPRCYocZkya7MFIlWIEYPWQZj+Gaksg6EyUaY255ZDqpQuA==}
+    engines: {node: '>=18.20.0 <20 || >=20.12.1'}
+
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
@@ -2680,6 +2706,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -2885,6 +2914,10 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  propagate@2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -3114,6 +3147,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -4220,6 +4256,15 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
+  '@mswjs/interceptors@0.41.6':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4233,6 +4278,15 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@openrouter/ai-sdk-provider@2.8.1(ai@6.0.168(zod@3.25.76))(zod@3.25.76)':
     dependencies:
@@ -5637,6 +5691,8 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-node-process@1.2.0: {}
+
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -5677,6 +5733,8 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-safe@5.0.1: {}
 
   jsonschema@1.5.0: {}
 
@@ -5890,6 +5948,12 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  nock@14.0.13:
+    dependencies:
+      '@mswjs/interceptors': 0.41.6
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+
   node-abort-controller@3.1.1: {}
 
   node-gyp-build-optional-packages@5.2.2:
@@ -5947,6 +6011,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  outvariant@1.4.3: {}
 
   p-limit@3.1.0:
     dependencies:
@@ -6137,6 +6203,8 @@ snapshots:
       parse-ms: 4.0.0
 
   process-warning@5.0.0: {}
+
+  propagate@2.0.1: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -6365,6 +6433,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
 


### PR DESCRIPTION
Closes #12.

## Summary
Adds the missing fetch step to the enrichment pipeline so that URLs posted without a client-supplied `content` are extracted server-side via Jina Reader (articles) and oEmbed (tweets, YouTube). Status maps cleanly to the PRD's done / degraded / failed contract.

## Changes
- `apps/api/app/services/fetch_provider.ts` — new `FetchProvider` service: Jina Reader for articles, oEmbed for tweet/youtube, 15s timeout, follows redirects
- `apps/api/app/jobs/enrich_bookmark_job.ts` — fetch stage runs before LLM when no client content; outcome mapping (success → done, meta_only → degraded, dead → failed/url_dead); persists `ogImage` + `embedData`
- `apps/api/start/env.ts` — adds `STASHIT_FETCH_PROVIDER`, `STASHIT_FETCH_API_KEY`
- `.env.example` (root + apps/api) — documents the new env vars
- `apps/api/tests/unit/fetch_provider.spec.ts` — 6 unit cases (article success/empty/404/403, tweet, youtube) using nock
- `apps/api/tests/functional/auto_fetch.spec.ts` — 4 E2E cases (auto-fetch happy path, dead URL, empty/degraded, content skip)
- `apps/api/tests/functional/refresh_bookmark.spec.ts` — mocks `FetchProvider` for the refresh path
- `apps/api/package.json` — adds `nock` as devDependency

## Test plan
- [x] CI passes
- [x] Manual smoke: `POST /bookmarks {"url":"https://example.com/article"}` lands `done` with content fetched from Jina