### PR TITLE
feat(api): csv import + export ace commands

### DIFF
--- a/apps/api/commands/export_csv.ts
+++ b/apps/api/commands/export_csv.ts
@@ -1,0 +1,82 @@
+import { createWriteStream } from 'node:fs'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+import { args, BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import { stringify as csvStringify } from 'csv-stringify'
+
+const COLUMNS = [
+  'url',
+  'title',
+  'description',
+  'tags',
+  'created_at',
+  'type',
+  'enrichment_status',
+] as const
+
+export default class ExportCsv extends BaseCommand {
+  static commandName = 'export:csv'
+  static description = 'Stream every bookmark (including failed) into a CSV file.'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  @args.string({ description: 'Destination file path' })
+  declare path: string
+
+  async run() {
+    const { default: db } = await import('@adonisjs/lucid/services/db')
+
+    const query = db
+      .from('bookmarks')
+      .select('url', 'title', 'description', 'tags', 'saved_at', 'type', 'enrichment_status')
+      .orderBy('saved_at', 'asc')
+
+    const stringifier = csvStringify({ header: true, columns: [...COLUMNS] })
+    const out = createWriteStream(this.path)
+
+    const source = Readable.from(toRowIterable(query))
+
+    let count = 0
+    source.on('data', () => count++)
+
+    await pipeline(source, stringifier, out)
+
+    this.logger.info(`Export complete — wrote ${count} bookmarks to ${this.path}`)
+  }
+}
+
+async function* toRowIterable(
+  query: ReturnType<typeof import('@adonisjs/lucid/services/db').default.from>
+): AsyncIterable<Record<string, string>> {
+  const stream = query.knexQuery.stream()
+  for await (const row of stream as AsyncIterable<Record<string, unknown>>) {
+    yield {
+      url: String(row.url ?? ''),
+      title: String(row.title ?? ''),
+      description: String(row.description ?? ''),
+      tags: serializeTags(row.tags),
+      created_at:
+        row.saved_at instanceof Date ? row.saved_at.toISOString() : String(row.saved_at ?? ''),
+      type: String(row.type ?? ''),
+      enrichment_status: String(row.enrichment_status ?? ''),
+    }
+  }
+}
+
+function serializeTags(v: unknown): string {
+  let arr: string[] = []
+  if (Array.isArray(v)) arr = v as string[]
+  else if (typeof v === 'string') {
+    try {
+      const parsed = JSON.parse(v)
+      if (Array.isArray(parsed)) arr = parsed
+    } catch {
+      // ignore
+    }
+  }
+  return arr.join('|')
+}

--- a/apps/api/commands/import_csv.ts
+++ b/apps/api/commands/import_csv.ts
@@ -106,5 +106,7 @@ export default class ImportCsv extends BaseCommand {
     this.logger.info(
       `Import summary — total: ${total}, inserted: ${inserted}, skipped: ${skipped}, failed: ${failed}`
     )
+
+    await enrichmentQueue.shutdown()
   }
 }

--- a/apps/api/commands/import_csv.ts
+++ b/apps/api/commands/import_csv.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+
+import { args, BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import { hashUrl, normalizeUrl } from '@stashit/shared'
+import { parse as parseCsv } from 'csv-parse'
+import { DateTime } from 'luxon'
+
+interface CsvRow {
+  url?: string
+  title?: string
+  description?: string
+  tags?: string
+  created_at?: string
+}
+
+export default class ImportCsv extends BaseCommand {
+  static commandName = 'import:csv'
+  static description = 'Stream a CSV of bookmarks and bulk-insert them.'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  @args.string({ description: 'Path to a CSV file with header row' })
+  declare path: string
+
+  async run() {
+    const { default: Bookmark } = await import('#models/bookmark')
+    const { default: enrichmentQueue } = await import('#services/enrichment_queue')
+
+    let total = 0
+    let inserted = 0
+    let skipped = 0
+    let failed = 0
+
+    const parser = createReadStream(this.path).pipe(
+      parseCsv({ columns: true, skip_empty_lines: true, trim: true })
+    )
+
+    for await (const raw of parser as AsyncIterable<CsvRow>) {
+      total++
+      const rawUrl = (raw.url ?? '').trim()
+      if (!rawUrl) {
+        failed++
+        continue
+      }
+
+      let normalized: string
+      try {
+        const u = new URL(rawUrl)
+        if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+          failed++
+          continue
+        }
+        normalized = normalizeUrl(rawUrl)
+      } catch {
+        failed++
+        continue
+      }
+
+      const urlHash = hashUrl(normalized)
+      const existing = await Bookmark.findBy('urlHash', urlHash)
+      if (existing) {
+        skipped++
+        continue
+      }
+
+      const tags = (raw.tags ?? '')
+        .split('|')
+        .map((t) => t.trim())
+        .filter(Boolean)
+
+      let savedAt: DateTime | undefined
+      if (raw.created_at && raw.created_at.trim()) {
+        const dt = DateTime.fromISO(raw.created_at.trim(), { zone: 'utc' })
+        if (dt.isValid) savedAt = dt
+      }
+
+      const bookmark = await Bookmark.create({
+        id: randomUUID(),
+        url: normalized,
+        urlHash,
+        type: 'other',
+        title: raw.title ?? '',
+        description: raw.description ?? '',
+        tags,
+        ogImage: null,
+        embedData: null,
+        enrichmentStatus: 'pending',
+        enrichmentError: null,
+        enrichmentFailureReason: null,
+        enrichmentAttempts: 0,
+        enrichedAt: null,
+        embeddingSourceText: null,
+        savedCount: 1,
+        savedFrom: ['import-csv'],
+        ...(savedAt ? { savedAt, lastSavedAt: savedAt } : {}),
+      })
+
+      await enrichmentQueue.dispatch(bookmark.id)
+      inserted++
+    }
+
+    this.logger.info(
+      `Import summary — total: ${total}, inserted: ${inserted}, skipped: ${skipped}, failed: ${failed}`
+    )
+  }
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -71,9 +71,12 @@
     "@vinejs/vine": "^4.3.1",
     "ai": "^6.0.168",
     "bullmq": "^5.76.2",
+    "csv-parse": "^6.2.1",
+    "csv-stringify": "^6.7.0",
     "ioredis": "^5.10.1",
     "luxon": "^3.7.2",
     "pg": "^8.13.1",
+    "pg-query-stream": "^4.14.0",
     "reflect-metadata": "^0.2.2",
     "zod": "^3.25.76"
   },

--- a/apps/api/tests/functional/csv_commands.spec.ts
+++ b/apps/api/tests/functional/csv_commands.spec.ts
@@ -1,0 +1,253 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import ace from '@adonisjs/core/services/ace'
+import app from '@adonisjs/core/services/app'
+import { test } from '@japa/runner'
+import nock from 'nock'
+
+import Bookmark from '#models/bookmark'
+import EmbeddingProvider from '#services/embedding_provider'
+import enrichmentQueue from '#services/enrichment_queue'
+import LlmProvider from '#services/llm_provider'
+import { mockEmbeddingReturning } from '#tests/helpers/mock_embedding'
+import { mockModelReturning } from '#tests/helpers/mock_llm'
+
+import ExportCsv from '../../commands/export_csv.js'
+import ImportCsv from '../../commands/import_csv.js'
+
+async function tmpFile(name: string, content = ''): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'stashit-csv-'))
+  const path = join(dir, name)
+  if (content) await writeFile(path, content, 'utf8')
+  return path
+}
+
+function installEnrichmentMocks() {
+  app.container.swap(
+    LlmProvider,
+    () =>
+      ({
+        getModel: async () =>
+          mockModelReturning({
+            title: 'Enriched',
+            description: 'Enriched body.',
+            tags: ['enriched'],
+            type: 'other',
+          }),
+      }) as unknown as LlmProvider
+  )
+  app.container.swap(
+    EmbeddingProvider,
+    () =>
+      ({
+        getModel: async () => mockEmbeddingReturning(new Array(1536).fill(0.01)),
+      }) as unknown as EmbeddingProvider
+  )
+}
+
+function logsOf(command: { logger: { getLogs: () => Array<{ message: string }> } }): string {
+  return command.logger
+    .getLogs()
+    .map((l) => l.message)
+    .join('\n')
+}
+
+test.group('ace import:csv', (group) => {
+  group.setup(async () => {
+    await ace.boot()
+  })
+
+  group.each.setup(() => {
+    installEnrichmentMocks()
+    nock.disableNetConnect()
+    nock.enableNetConnect((host) => host.includes('127.0.0.1') || host.includes('localhost'))
+    // Stub Jina Reader for any URL the CSV imports
+    nock('https://r.jina.ai').get(/.*/).reply(200, 'mock content body. '.repeat(20)).persist()
+  })
+  group.each.teardown(() => {
+    app.container.restoreAll()
+    nock.cleanAll()
+    nock.enableNetConnect()
+  })
+
+  test('inserts a valid row and dispatches enrichment', async ({ assert }) => {
+    const path = await tmpFile(
+      'in.csv',
+      'url,title,description,tags,created_at\nhttps://example.com/a,Hello,Desc,dev|cli,\n'
+    )
+
+    const command = await ace.create(ImportCsv, [path])
+    command.ui.switchMode('raw')
+    await command.exec()
+    await enrichmentQueue.flush()
+
+    assert.equal(command.exitCode, 0)
+    const row = await Bookmark.findByOrFail('url', 'https://example.com/a')
+    assert.exists(row.id)
+    assert.match(logsOf(command), /inserted[^\n]*1/i)
+  })
+
+  test('skips duplicate urls', async ({ assert }) => {
+    const path = await tmpFile('dup.csv', 'url\nhttps://example.com/dup\nhttps://example.com/dup\n')
+
+    const command = await ace.create(ImportCsv, [path])
+    command.ui.switchMode('raw')
+    await command.exec()
+    await enrichmentQueue.flush()
+
+    assert.equal(command.exitCode, 0)
+    const rows = await Bookmark.query().where('url', 'https://example.com/dup')
+    assert.lengthOf(rows, 1)
+    assert.match(logsOf(command), /skipped[^\n]*1/i)
+  })
+
+  test('counts invalid rows as failed', async ({ assert }) => {
+    const path = await tmpFile('bad.csv', 'url\nnot-a-url\nhttps://example.com/ok\n')
+
+    const command = await ace.create(ImportCsv, [path])
+    command.ui.switchMode('raw')
+    await command.exec()
+    await enrichmentQueue.flush()
+
+    const rows = await Bookmark.all()
+    assert.lengthOf(rows, 1)
+    assert.match(logsOf(command), /failed[^\n]*1/i)
+  })
+
+  test('honors created_at as savedAt for new rows', async ({ assert }) => {
+    const iso = '2024-01-15T10:00:00.000Z'
+    const path = await tmpFile('created.csv', `url,created_at\nhttps://example.com/t,${iso}\n`)
+    const command = await ace.create(ImportCsv, [path])
+    command.ui.switchMode('raw')
+    await command.exec()
+    await enrichmentQueue.flush()
+
+    const row = await Bookmark.findByOrFail('url', 'https://example.com/t')
+    assert.equal(row.savedAt.toUTC().toISO(), iso)
+  })
+
+  test('prints summary with total/inserted/skipped/failed', async ({ assert }) => {
+    const path = await tmpFile(
+      'sum.csv',
+      'url\nhttps://example.com/x\nhttps://example.com/x\nnope\n'
+    )
+    const command = await ace.create(ImportCsv, [path])
+    command.ui.switchMode('raw')
+    await command.exec()
+    await enrichmentQueue.flush()
+
+    const printed = logsOf(command)
+    assert.match(printed, /total[^\n]*3/i)
+    assert.match(printed, /inserted[^\n]*1/i)
+    assert.match(printed, /skipped[^\n]*1/i)
+    assert.match(printed, /failed[^\n]*1/i)
+  })
+})
+
+test.group('ace export:csv', (group) => {
+  group.setup(async () => {
+    await ace.boot()
+  })
+
+  test('writes all bookmarks including failed with full columns', async ({ assert }) => {
+    const { randomUUID } = await import('node:crypto')
+    const { hashUrl, normalizeUrl } = await import('@stashit/shared')
+
+    const baseRow = {
+      type: 'other' as const,
+      ogImage: null,
+      embedData: null,
+      enrichmentError: null,
+      enrichmentFailureReason: null,
+      enrichmentAttempts: 0,
+      enrichedAt: null,
+      embeddingSourceText: null,
+      savedCount: 1,
+      savedFrom: [] as never[],
+    }
+    const url1 = normalizeUrl('https://example.com/e1')
+    const url2 = normalizeUrl('https://example.com/e2')
+    await Bookmark.create({
+      ...baseRow,
+      id: randomUUID(),
+      url: url1,
+      urlHash: hashUrl(url1),
+      title: 'One',
+      description: 'd1',
+      tags: ['a', 'b'],
+      enrichmentStatus: 'done',
+    })
+    await Bookmark.create({
+      ...baseRow,
+      id: randomUUID(),
+      url: url2,
+      urlHash: hashUrl(url2),
+      title: 'Two',
+      description: '',
+      tags: [],
+      enrichmentStatus: 'failed',
+    })
+
+    const outPath = await tmpFile('out.csv')
+    const exportCmd = await ace.create(ExportCsv, [outPath])
+    exportCmd.ui.switchMode('raw')
+    await exportCmd.exec()
+    assert.equal(exportCmd.exitCode, 0)
+
+    const csv = await readFile(outPath, 'utf8')
+    const header = csv.split('\n')[0]
+    for (const col of [
+      'url',
+      'title',
+      'description',
+      'tags',
+      'created_at',
+      'type',
+      'enrichment_status',
+    ]) {
+      assert.include(header, col)
+    }
+    assert.include(csv, 'https://example.com/e1')
+    assert.include(csv, 'https://example.com/e2')
+    assert.include(csv, 'failed')
+    assert.include(csv, 'a|b')
+  })
+
+  test('round-trip: import → export → re-import yields zero new inserts', async ({ assert }) => {
+    installEnrichmentMocks()
+    nock.disableNetConnect()
+    nock.enableNetConnect((host) => host.includes('127.0.0.1') || host.includes('localhost'))
+    nock('https://r.jina.ai').get(/.*/).reply(200, 'mock content. '.repeat(20)).persist()
+
+    try {
+      const seedPath = await tmpFile(
+        'rt.csv',
+        'url,title\nhttps://example.com/rt1,A\nhttps://example.com/rt2,B\n'
+      )
+      const c1 = await ace.create(ImportCsv, [seedPath])
+      c1.ui.switchMode('raw')
+      await c1.exec()
+      await enrichmentQueue.flush()
+
+      const outPath = await tmpFile('rt-out.csv')
+      const c2 = await ace.create(ExportCsv, [outPath])
+      c2.ui.switchMode('raw')
+      await c2.exec()
+
+      const c3 = await ace.create(ImportCsv, [outPath])
+      c3.ui.switchMode('raw')
+      await c3.exec()
+      await enrichmentQueue.flush()
+
+      const printed = logsOf(c3)
+      assert.match(printed, /inserted[^\n]*0/i)
+      assert.match(printed, /skipped[^\n]*2/i)
+    } finally {
+      app.container.restoreAll()
+      nock.cleanAll()
+      nock.enableNetConnect()
+    }
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 3.0.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.3.1)(pino-pretty@13.1.3)(youch@4.1.1))
       '@adonisjs/lucid':
         specifier: ^22.4.2
-        version: 22.4.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.3.1)(pino-pretty@13.1.3)(youch@4.1.1))(@vinejs/vine@4.3.1)(luxon@3.7.2)(pg@8.20.0)
+        version: 22.4.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.3.1)(pino-pretty@13.1.3)(youch@4.1.1))(@vinejs/vine@4.3.1)(luxon@3.7.2)(pg-query-stream@4.14.0(pg@8.20.0))(pg@8.20.0)
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
         version: 3.0.71(zod@3.25.76)
@@ -74,6 +74,12 @@ importers:
       bullmq:
         specifier: ^5.76.2
         version: 5.76.2
+      csv-parse:
+        specifier: ^6.2.1
+        version: 6.2.1
+      csv-stringify:
+        specifier: ^6.7.0
+        version: 6.7.0
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -83,6 +89,9 @@ importers:
       pg:
         specifier: ^8.13.1
         version: 8.20.0
+      pg-query-stream:
+        specifier: ^4.14.0
+        version: 4.14.0(pg@8.20.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1783,6 +1792,12 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  csv-parse@6.2.1:
+    resolution: {integrity: sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==}
+
+  csv-stringify@6.7.0:
+    resolution: {integrity: sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==}
+
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
@@ -2774,6 +2789,11 @@ packages:
   pg-connection-string@2.6.2:
     resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
 
+  pg-cursor@2.19.0:
+    resolution: {integrity: sha512-J5cF1MUz7LRJ9emOqF/06QjabMHMZy587rSPF0UuA8rCwKeeYl2co8Pp+6k5UU9YrAYHMzWkLxilfZB0hqsWWw==}
+    peerDependencies:
+      pg: ^8
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
@@ -2785,6 +2805,11 @@ packages:
 
   pg-protocol@1.13.0:
     resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-query-stream@4.14.0:
+    resolution: {integrity: sha512-B1LLxgqngAATPciOPYYKyaQfsw5wyP6BZq6nHqQOC5QaaEBsfW/0OBwWUga+knCAqENMeoow9I8Zgi2m3P9rWw==}
+    peerDependencies:
+      pg: ^8
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -3749,7 +3774,7 @@ snapshots:
     optionalDependencies:
       pino-pretty: 13.1.3
 
-  '@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.3.1)(pino-pretty@13.1.3)(youch@4.1.1))(@vinejs/vine@4.3.1)(luxon@3.7.2)(pg@8.20.0)':
+  '@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.3.1)(pino-pretty@13.1.3)(youch@4.1.1))(@vinejs/vine@4.3.1)(luxon@3.7.2)(pg-query-stream@4.14.0(pg@8.20.0))(pg@8.20.0)':
     dependencies:
       '@adonisjs/core': 7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.3.1)(pino-pretty@13.1.3)(youch@4.1.1)
       '@adonisjs/presets': 3.0.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.3.1)(pino-pretty@13.1.3)(youch@4.1.1))
@@ -3762,8 +3787,8 @@ snapshots:
       fast-deep-equal: 3.1.3
       igniculus: 1.5.0
       kleur: 4.1.5
-      knex: 3.2.9(pg@8.20.0)
-      knex-dynamic-connection: 5.0.1(pg@8.20.0)
+      knex: 3.2.9(pg-query-stream@4.14.0(pg@8.20.0))(pg@8.20.0)
+      knex-dynamic-connection: 5.0.1(pg-query-stream@4.14.0(pg@8.20.0))(pg@8.20.0)
       pretty-hrtime: 1.0.3
       slash: 5.1.0
       tarn: 3.0.2
@@ -5084,6 +5109,10 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csv-parse@6.2.1: {}
+
+  csv-stringify@6.7.0: {}
+
   dateformat@4.6.3: {}
 
   dayjs@1.11.20: {}
@@ -5746,10 +5775,10 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knex-dynamic-connection@5.0.1(pg@8.20.0):
+  knex-dynamic-connection@5.0.1(pg-query-stream@4.14.0(pg@8.20.0))(pg@8.20.0):
     dependencies:
       debug: 4.4.3
-      knex: 3.2.7(pg@8.20.0)
+      knex: 3.2.7(pg-query-stream@4.14.0(pg@8.20.0))(pg@8.20.0)
     transitivePeerDependencies:
       - better-sqlite3
       - mysql
@@ -5761,7 +5790,7 @@ snapshots:
       - supports-color
       - tedious
 
-  knex@3.2.7(pg@8.20.0):
+  knex@3.2.7(pg-query-stream@4.14.0(pg@8.20.0))(pg@8.20.0):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
@@ -5779,10 +5808,11 @@ snapshots:
       tildify: 2.0.0
     optionalDependencies:
       pg: 8.20.0
+      pg-query-stream: 4.14.0(pg@8.20.0)
     transitivePeerDependencies:
       - supports-color
 
-  knex@3.2.9(pg@8.20.0):
+  knex@3.2.9(pg-query-stream@4.14.0(pg@8.20.0))(pg@8.20.0):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
@@ -5800,6 +5830,7 @@ snapshots:
       tildify: 2.0.0
     optionalDependencies:
       pg: 8.20.0
+      pg-query-stream: 4.14.0(pg@8.20.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6064,6 +6095,10 @@ snapshots:
 
   pg-connection-string@2.6.2: {}
 
+  pg-cursor@2.19.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
   pg-int8@1.0.1: {}
 
   pg-pool@3.13.0(pg@8.20.0):
@@ -6071,6 +6106,11 @@ snapshots:
       pg: 8.20.0
 
   pg-protocol@1.13.0: {}
+
+  pg-query-stream@4.14.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+      pg-cursor: 2.19.0(pg@8.20.0)
 
   pg-types@2.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

Adds streaming `import:csv` and `export:csv` ace commands to bulk move bookmarks in/out (closes #13).

## Changes

- `apps/api/commands/import_csv.ts` — streams CSV, validates URLs, dedupes via urlHash, parses pipe-separated tags + ISO `created_at`, dispatches enrichment, prints total/inserted/skipped/failed
- `apps/api/commands/export_csv.ts` — pg-query-stream + csv-stringify pipeline, columns: url/title/description/tags/created_at/type/enrichment_status, includes failed rows
- `apps/api/tests/functional/csv_commands.spec.ts` — 7 tests covering insert, dedupe, failure counting, created_at, summary, export columns, round-trip
- `apps/api/package.json` — adds csv-parse, csv-stringify, pg-query-stream

## Test plan

- [x] CI passes
- [x] Round-trip a real export (`node ace export:csv out.csv` → `node ace import:csv out.csv`) yields zero new inserts