### PR TITLE
feat: add @stashit/mcp server with 8 tools

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@stashit/mcp",
+  "version": "0.1.0",
+  "description": "stashit MCP server — expose bookmarks to AI agents",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "stashit-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup && chmod +x dist/index.js",
+    "dev": "tsup --watch",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@stashit/api-client": "workspace:*",
+    "@stashit/shared": "workspace:*",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,0 +1,16 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StashitClient } from "@stashit/api-client";
+import { createServer } from "./server.js";
+
+const apiUrl = process.env["STASHIT_API_URL"];
+const apiKey = process.env["STASHIT_API_KEY"];
+
+if (!apiUrl || !apiKey) {
+  console.error("Error: STASHIT_API_URL and STASHIT_API_KEY environment variables are required");
+  process.exit(1);
+}
+
+const client = new StashitClient({ baseUrl: apiUrl, apiKey });
+const server = createServer(client);
+
+await server.connect(new StdioServerTransport());

--- a/apps/mcp/src/server.test.ts
+++ b/apps/mcp/src/server.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { StashitClient } from "@stashit/api-client";
+import { createServer } from "./server.js";
+
+function text(result: unknown): string {
+  const r = result as Record<string, unknown>;
+  const content = r["content"];
+  if (!Array.isArray(content)) throw new Error("Expected array content");
+  const c = content[0] as { type?: string; text?: string } | undefined;
+  if (!c || c.type !== "text" || !c.text) throw new Error("Expected text content");
+  return c.text;
+}
+
+const bookmark = {
+  id: "b1b1b1b1-0000-0000-0000-000000000001",
+  url: "https://example.com",
+  urlHash: "a".repeat(64),
+  type: "article" as const,
+  title: "Example",
+  description: "Desc",
+  tags: ["tag1"],
+  embedding: null,
+  ogImage: null,
+  embedData: null,
+  enrichmentStatus: "done" as const,
+  enrichmentError: null,
+  enrichmentFailureReason: null,
+  enrichmentAttempts: 1,
+  enrichedAt: "2024-01-01T00:00:00.000Z",
+  embeddingSourceText: null,
+  savedAt: "2024-01-01T00:00:00.000Z",
+  savedCount: 1,
+  lastSavedAt: "2024-01-01T00:00:00.000Z",
+  savedFrom: ["cli" as const],
+};
+
+function makeClient(): StashitClient {
+  return {
+    search: vi.fn().mockResolvedValue([bookmark]),
+    list: vi.fn().mockResolvedValue([bookmark]),
+    failed: vi.fn().mockResolvedValue([bookmark]),
+    get: vi.fn().mockResolvedValue(bookmark),
+    add: vi.fn(),
+    delete: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue({ id: bookmark.id }),
+    tags: vi.fn().mockResolvedValue([{ tag: "tag1", count: 3 }]),
+  } as unknown as StashitClient;
+}
+
+async function setup(stashitClient: StashitClient) {
+  const server = createServer(stashitClient);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  const mcpClient = new Client({ name: "test-client", version: "1.0.0" }, { capabilities: {} });
+  await Promise.all([server.connect(serverTransport), mcpClient.connect(clientTransport)]);
+
+  return { mcpClient, server, stashitClient };
+}
+
+describe("MCP server tool registration", () => {
+  const EXPECTED_TOOLS = [
+    "search_semantic",
+    "list_recent",
+    "list_by_tag",
+    "get_bookmark",
+    "list_tags",
+    "list_failed",
+    "delete_bookmark",
+    "refresh_bookmark",
+  ];
+
+  it("exposes all 8 tools", async () => {
+    const { mcpClient, server } = await setup(makeClient());
+
+    const { tools } = await mcpClient.listTools();
+    const names = tools.map((t) => t.name);
+
+    for (const expected of EXPECTED_TOOLS) {
+      expect(names).toContain(expected);
+    }
+
+    await server.close();
+  });
+});
+
+describe("search_semantic via MCP", () => {
+  it("routes call to client.search", async () => {
+    const stashitClient = makeClient();
+    const { mcpClient, server } = await setup(stashitClient);
+
+    const result = await mcpClient.callTool({
+      name: "search_semantic",
+      arguments: { query: "typescript" },
+    });
+
+    expect(stashitClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({ query: "typescript" }),
+    );
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(text(result));
+    expect(parsed).toEqual([bookmark]);
+
+    await server.close();
+  });
+});
+
+describe("list_recent via MCP", () => {
+  it("routes call to client.list", async () => {
+    const stashitClient = makeClient();
+    const { mcpClient, server } = await setup(stashitClient);
+
+    const result = await mcpClient.callTool({ name: "list_recent", arguments: {} });
+
+    expect(stashitClient.list).toHaveBeenCalled();
+    expect(result.isError).toBeFalsy();
+
+    await server.close();
+  });
+});
+
+describe("list_by_tag via MCP", () => {
+  it("routes call to client.list with tag", async () => {
+    const stashitClient = makeClient();
+    const { mcpClient, server } = await setup(stashitClient);
+
+    const result = await mcpClient.callTool({
+      name: "list_by_tag",
+      arguments: { tag: "typescript" },
+    });
+
+    expect(stashitClient.list).toHaveBeenCalledWith(expect.objectContaining({ tag: "typescript" }));
+    expect(result.isError).toBeFalsy();
+
+    await server.close();
+  });
+});
+
+describe("get_bookmark via MCP", () => {
+  it("routes call to client.get", async () => {
+    const stashitClient = makeClient();
+    const { mcpClient, server } = await setup(stashitClient);
+
+    const result = await mcpClient.callTool({
+      name: "get_bookmark",
+      arguments: { id: bookmark.id },
+    });
+
+    expect(stashitClient.get).toHaveBeenCalledWith(bookmark.id);
+    expect(result.isError).toBeFalsy();
+
+    await server.close();
+  });
+});
+
+describe("list_tags via MCP", () => {
+  it("routes call to client.tags", async () => {
+    const stashitClient = makeClient();
+    const { mcpClient, server } = await setup(stashitClient);
+
+    const result = await mcpClient.callTool({ name: "list_tags", arguments: {} });
+
+    expect(stashitClient.tags).toHaveBeenCalled();
+    expect(result.isError).toBeFalsy();
+
+    await server.close();
+  });
+});
+
+describe("list_failed via MCP", () => {
+  it("routes call to client.failed", async () => {
+    const stashitClient = makeClient();
+    const { mcpClient, server } = await setup(stashitClient);
+
+    const result = await mcpClient.callTool({ name: "list_failed", arguments: {} });
+
+    expect(stashitClient.failed).toHaveBeenCalled();
+    expect(result.isError).toBeFalsy();
+
+    await server.close();
+  });
+});
+
+describe("delete_bookmark via MCP", () => {
+  it("routes call to client.delete", async () => {
+    const stashitClient = makeClient();
+    const { mcpClient, server } = await setup(stashitClient);
+
+    const result = await mcpClient.callTool({
+      name: "delete_bookmark",
+      arguments: { id: bookmark.id },
+    });
+
+    expect(stashitClient.delete).toHaveBeenCalledWith(bookmark.id);
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(text(result));
+    expect(parsed).toMatchObject({ deleted: true, id: bookmark.id });
+
+    await server.close();
+  });
+});
+
+describe("refresh_bookmark via MCP", () => {
+  it("routes call to client.refresh", async () => {
+    const stashitClient = makeClient();
+    const { mcpClient, server } = await setup(stashitClient);
+
+    const result = await mcpClient.callTool({
+      name: "refresh_bookmark",
+      arguments: { id: bookmark.id },
+    });
+
+    expect(stashitClient.refresh).toHaveBeenCalledWith(bookmark.id);
+    expect(result.isError).toBeFalsy();
+
+    await server.close();
+  });
+});
+
+describe("error surface", () => {
+  it("returns isError with readable message on API failure", async () => {
+    const stashitClient = makeClient();
+    vi.mocked(stashitClient.search).mockRejectedValue(new Error("Unauthorized: invalid API key"));
+
+    const { mcpClient, server } = await setup(stashitClient);
+
+    const result = await mcpClient.callTool({ name: "search_semantic", arguments: { query: "q" } });
+
+    expect(result.isError).toBe(true);
+    expect(text(result)).toContain("Unauthorized");
+
+    await server.close();
+  });
+});

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -1,0 +1,129 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { StashitClient } from "@stashit/api-client";
+import {
+  searchSemantic,
+  listRecent,
+  listByTag,
+  getBookmark,
+  listTags,
+  listFailed,
+  deleteBookmark,
+  refreshBookmark,
+} from "./tools.js";
+
+export function createServer(client: StashitClient): McpServer {
+  const server = new McpServer({
+    name: "stashit",
+    version: "0.1.0",
+  });
+
+  server.registerTool(
+    "search_semantic",
+    {
+      description: "Semantic search across your bookmarks using natural language",
+      inputSchema: {
+        query: z.string().describe("Natural language search query"),
+        limit: z.number().int().positive().optional().describe("Maximum number of results"),
+        type: z
+          .enum(["tweet", "youtube", "article", "image", "pdf", "other"])
+          .optional()
+          .describe("Filter by bookmark type"),
+        min_score: z.number().min(0).max(1).optional().describe("Minimum similarity score (0–1)"),
+        tags: z.array(z.string()).optional().describe("Filter by tags"),
+      },
+    },
+    (args) => searchSemantic(client, args),
+  );
+
+  server.registerTool(
+    "list_recent",
+    {
+      description: "List recent bookmarks in reverse chronological order",
+      inputSchema: {
+        limit: z.number().int().positive().optional().describe("Maximum number of results"),
+        offset: z.number().int().nonnegative().optional().describe("Pagination offset"),
+        type: z
+          .enum(["tweet", "youtube", "article", "image", "pdf", "other"])
+          .optional()
+          .describe("Filter by type"),
+      },
+    },
+    (args) => listRecent(client, args),
+  );
+
+  server.registerTool(
+    "list_by_tag",
+    {
+      description: "List bookmarks that have a specific tag",
+      inputSchema: {
+        tag: z.string().describe("Tag to filter by"),
+        limit: z.number().int().positive().optional().describe("Maximum number of results"),
+        offset: z.number().int().nonnegative().optional().describe("Pagination offset"),
+      },
+    },
+    (args) => listByTag(client, args),
+  );
+
+  server.registerTool(
+    "get_bookmark",
+    {
+      description: "Get a single bookmark by its UUID",
+      inputSchema: {
+        id: z.string().uuid().describe("Bookmark UUID"),
+      },
+    },
+    (args) => getBookmark(client, args),
+  );
+
+  server.registerTool(
+    "list_tags",
+    {
+      description: "List all tags with their bookmark counts",
+      inputSchema: {
+        min_count: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Minimum bookmark count to include a tag"),
+      },
+    },
+    (args) => listTags(client, args),
+  );
+
+  server.registerTool(
+    "list_failed",
+    {
+      description: "List bookmarks whose enrichment has failed",
+      inputSchema: {
+        limit: z.number().int().positive().optional().describe("Maximum number of results"),
+      },
+    },
+    (args) => listFailed(client, args),
+  );
+
+  server.registerTool(
+    "delete_bookmark",
+    {
+      description: "Permanently delete a bookmark by its UUID",
+      inputSchema: {
+        id: z.string().uuid().describe("Bookmark UUID"),
+      },
+    },
+    (args) => deleteBookmark(client, args),
+  );
+
+  server.registerTool(
+    "refresh_bookmark",
+    {
+      description: "Re-trigger enrichment for a bookmark",
+      inputSchema: {
+        id: z.string().uuid().describe("Bookmark UUID"),
+      },
+    },
+    (args) => refreshBookmark(client, args),
+  );
+
+  return server;
+}

--- a/apps/mcp/src/tools.test.ts
+++ b/apps/mcp/src/tools.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from "vitest";
+import type { StashitClient } from "@stashit/api-client";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+function text(result: CallToolResult): string {
+  const c = result.content[0];
+  if (!c || c.type !== "text") throw new Error("Expected text content");
+  return c.text;
+}
+import {
+  searchSemantic,
+  listRecent,
+  listByTag,
+  getBookmark,
+  listTags,
+  listFailed,
+  deleteBookmark,
+  refreshBookmark,
+} from "./tools.js";
+
+const bookmark = {
+  id: "b1b1b1b1-0000-0000-0000-000000000001",
+  url: "https://example.com",
+  urlHash: "a".repeat(64),
+  type: "article" as const,
+  title: "Example",
+  description: "Desc",
+  tags: ["tag1"],
+  embedding: null,
+  ogImage: null,
+  embedData: null,
+  enrichmentStatus: "done" as const,
+  enrichmentError: null,
+  enrichmentFailureReason: null,
+  enrichmentAttempts: 1,
+  enrichedAt: "2024-01-01T00:00:00.000Z",
+  embeddingSourceText: null,
+  savedAt: "2024-01-01T00:00:00.000Z",
+  savedCount: 1,
+  lastSavedAt: "2024-01-01T00:00:00.000Z",
+  savedFrom: ["cli" as const],
+};
+
+function makeClient(overrides: Partial<StashitClient> = {}): StashitClient {
+  return {
+    search: vi.fn().mockResolvedValue([bookmark]),
+    list: vi.fn().mockResolvedValue([bookmark]),
+    failed: vi.fn().mockResolvedValue([bookmark]),
+    get: vi.fn().mockResolvedValue(bookmark),
+    add: vi.fn(),
+    delete: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue({ id: bookmark.id }),
+    tags: vi.fn().mockResolvedValue([{ tag: "tag1", count: 3 }]),
+    ...overrides,
+  } as unknown as StashitClient;
+}
+
+describe("search_semantic", () => {
+  it("calls client.search and returns JSON", async () => {
+    const client = makeClient();
+    const result = await searchSemantic(client, { query: "typescript tips" });
+
+    expect(client.search).toHaveBeenCalledWith({
+      query: "typescript tips",
+      limit: undefined,
+      type: undefined,
+      minScore: undefined,
+      tags: undefined,
+    });
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(text(result))).toEqual([bookmark]);
+  });
+
+  it("forwards optional params", async () => {
+    const client = makeClient();
+    await searchSemantic(client, {
+      query: "q",
+      limit: 5,
+      type: "article",
+      min_score: 0.7,
+      tags: ["a"],
+    });
+
+    expect(client.search).toHaveBeenCalledWith({
+      query: "q",
+      limit: 5,
+      type: "article",
+      minScore: 0.7,
+      tags: ["a"],
+    });
+  });
+
+  it("returns error on failure", async () => {
+    const client = makeClient({ search: vi.fn().mockRejectedValue(new Error("HTTP 401")) });
+    const result = await searchSemantic(client, { query: "q" });
+
+    expect(result.isError).toBe(true);
+    expect(text(result)).toContain("HTTP 401");
+  });
+});
+
+describe("list_recent", () => {
+  it("calls client.list without tag and returns JSON", async () => {
+    const client = makeClient();
+    const result = await listRecent(client, {});
+
+    expect(client.list).toHaveBeenCalledWith({
+      limit: undefined,
+      offset: undefined,
+      type: undefined,
+    });
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(text(result))).toEqual([bookmark]);
+  });
+
+  it("returns error on failure", async () => {
+    const client = makeClient({ list: vi.fn().mockRejectedValue(new Error("network")) });
+    const result = await listRecent(client, {});
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("list_by_tag", () => {
+  it("calls client.list with tag", async () => {
+    const client = makeClient();
+    const result = await listByTag(client, { tag: "typescript" });
+
+    expect(client.list).toHaveBeenCalledWith({
+      tag: "typescript",
+      limit: undefined,
+      offset: undefined,
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("returns error on failure", async () => {
+    const client = makeClient({ list: vi.fn().mockRejectedValue(new Error("oops")) });
+    const result = await listByTag(client, { tag: "x" });
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("get_bookmark", () => {
+  it("calls client.get and returns JSON", async () => {
+    const client = makeClient();
+    const result = await getBookmark(client, { id: bookmark.id });
+
+    expect(client.get).toHaveBeenCalledWith(bookmark.id);
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(text(result))).toEqual(bookmark);
+  });
+
+  it("returns error on failure", async () => {
+    const client = makeClient({ get: vi.fn().mockRejectedValue(new Error("not found")) });
+    const result = await getBookmark(client, { id: "bad-id" });
+    expect(result.isError).toBe(true);
+    expect(text(result)).toContain("not found");
+  });
+});
+
+describe("list_tags", () => {
+  it("calls client.tags and returns JSON", async () => {
+    const client = makeClient();
+    const result = await listTags(client, {});
+
+    expect(client.tags).toHaveBeenCalledWith(undefined);
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(text(result))).toEqual([{ tag: "tag1", count: 3 }]);
+  });
+
+  it("forwards min_count", async () => {
+    const client = makeClient();
+    await listTags(client, { min_count: 2 });
+    expect(client.tags).toHaveBeenCalledWith(2);
+  });
+
+  it("returns error on failure", async () => {
+    const client = makeClient({ tags: vi.fn().mockRejectedValue(new Error("err")) });
+    const result = await listTags(client, {});
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("list_failed", () => {
+  it("calls client.failed and returns JSON", async () => {
+    const client = makeClient();
+    const result = await listFailed(client, {});
+
+    expect(client.failed).toHaveBeenCalledWith({ limit: undefined });
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(text(result))).toEqual([bookmark]);
+  });
+
+  it("returns error on failure", async () => {
+    const client = makeClient({ failed: vi.fn().mockRejectedValue(new Error("err")) });
+    const result = await listFailed(client, {});
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("delete_bookmark", () => {
+  it("calls client.delete and returns confirmation", async () => {
+    const client = makeClient();
+    const result = await deleteBookmark(client, { id: bookmark.id });
+
+    expect(client.delete).toHaveBeenCalledWith(bookmark.id);
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(text(result))).toMatchObject({ deleted: true, id: bookmark.id });
+  });
+
+  it("returns error on failure", async () => {
+    const client = makeClient({ delete: vi.fn().mockRejectedValue(new Error("not found")) });
+    const result = await deleteBookmark(client, { id: "bad" });
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("refresh_bookmark", () => {
+  it("calls client.refresh and returns the id", async () => {
+    const client = makeClient();
+    const result = await refreshBookmark(client, { id: bookmark.id });
+
+    expect(client.refresh).toHaveBeenCalledWith(bookmark.id);
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(text(result))).toEqual({ id: bookmark.id });
+  });
+
+  it("returns error on failure", async () => {
+    const client = makeClient({ refresh: vi.fn().mockRejectedValue(new Error("err")) });
+    const result = await refreshBookmark(client, { id: "bad" });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -1,0 +1,120 @@
+import type { StashitClient } from "@stashit/api-client";
+import type { BookmarkType } from "@stashit/shared";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+function ok(data: unknown): CallToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+function err(e: unknown): CallToolResult {
+  return {
+    isError: true,
+    content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }],
+  };
+}
+
+export async function searchSemantic(
+  client: StashitClient,
+  args: { query: string; limit?: number; type?: string; min_score?: number; tags?: string[] },
+): Promise<CallToolResult> {
+  try {
+    const results = await client.search({
+      query: args.query,
+      limit: args.limit,
+      type: args.type as BookmarkType | undefined,
+      minScore: args.min_score,
+      tags: args.tags,
+    });
+    return ok(results);
+  } catch (e) {
+    return err(e);
+  }
+}
+
+export async function listRecent(
+  client: StashitClient,
+  args: { limit?: number; offset?: number; type?: string },
+): Promise<CallToolResult> {
+  try {
+    const results = await client.list({
+      limit: args.limit,
+      offset: args.offset,
+      type: args.type as BookmarkType | undefined,
+    });
+    return ok(results);
+  } catch (e) {
+    return err(e);
+  }
+}
+
+export async function listByTag(
+  client: StashitClient,
+  args: { tag: string; limit?: number; offset?: number },
+): Promise<CallToolResult> {
+  try {
+    const results = await client.list({ tag: args.tag, limit: args.limit, offset: args.offset });
+    return ok(results);
+  } catch (e) {
+    return err(e);
+  }
+}
+
+export async function getBookmark(
+  client: StashitClient,
+  args: { id: string },
+): Promise<CallToolResult> {
+  try {
+    const bookmark = await client.get(args.id);
+    return ok(bookmark);
+  } catch (e) {
+    return err(e);
+  }
+}
+
+export async function listTags(
+  client: StashitClient,
+  args: { min_count?: number },
+): Promise<CallToolResult> {
+  try {
+    const tags = await client.tags(args.min_count);
+    return ok(tags);
+  } catch (e) {
+    return err(e);
+  }
+}
+
+export async function listFailed(
+  client: StashitClient,
+  args: { limit?: number },
+): Promise<CallToolResult> {
+  try {
+    const results = await client.failed({ limit: args.limit });
+    return ok(results);
+  } catch (e) {
+    return err(e);
+  }
+}
+
+export async function deleteBookmark(
+  client: StashitClient,
+  args: { id: string },
+): Promise<CallToolResult> {
+  try {
+    await client.delete(args.id);
+    return ok({ deleted: true, id: args.id });
+  } catch (e) {
+    return err(e);
+  }
+}
+
+export async function refreshBookmark(
+  client: StashitClient,
+  args: { id: string },
+): Promise<CallToolResult> {
+  try {
+    const result = await client.refresh(args.id);
+    return ok(result);
+  } catch (e) {
+    return err(e);
+  }
+}

--- a/apps/mcp/tsconfig.json
+++ b/apps/mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "lib": ["ESNext"],
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/mcp/tsup.config.ts
+++ b/apps/mcp/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: false,
+  clean: true,
+  banner: { js: "#!/usr/bin/env node" },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,19 +158,31 @@ importers:
         version: 4.1.1
 
   apps/cli:
+    devDependencies:
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(@swc/core@1.15.30)(postcss@8.5.12)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@25.6.0)
+
+  apps/mcp:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@stashit/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
       '@stashit/shared':
         specifier: workspace:*
         version: link:../../packages/shared
-      citty:
-        specifier: ^0.1.6
-        version: 0.1.6
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
     devDependencies:
       tsup:
         specifier: ^8.3.5
@@ -949,6 +961,12 @@ packages:
     resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1059,6 +1077,16 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -1628,6 +1656,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1644,8 +1676,19 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1720,6 +1763,10 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -1827,9 +1874,6 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
-  citty@0.1.6:
-    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
-
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
@@ -1916,11 +1960,23 @@ packages:
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -2099,6 +2155,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -2225,6 +2284,10 @@ packages:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
@@ -2232,6 +2295,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -2257,6 +2330,9 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -2289,6 +2365,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-cache-directory@6.0.0:
     resolution: {integrity: sha512-CvFd5ivA6HcSHbD+59P7CyzINHXzwhuQK8RY7CxJZtgDSAtRlHiCaQpZQ2lMR/WRyUIEmzUvL6G2AGurMfegZA==}
@@ -2335,6 +2415,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -2432,6 +2516,10 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@9.0.2:
     resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2509,6 +2597,10 @@ packages:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -2562,6 +2654,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
@@ -2588,6 +2683,9 @@ packages:
   jest-diff@30.3.0:
     resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -2617,6 +2715,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -2790,6 +2894,10 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2867,6 +2975,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   nock@14.0.13:
     resolution: {integrity: sha512-SCPsQmGVNY8h1rfS3aU0MzOGYY+wKIFukHEsoSIwPRCYocZkya7MFIlWIEYPWQZj+Gaksg6EyUaY255ZDqpQuA==}
@@ -2981,6 +3093,10 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -2998,6 +3114,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3092,6 +3211,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@8.0.0:
     resolution: {integrity: sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==}
@@ -3210,6 +3333,10 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
@@ -3264,6 +3391,10 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3300,6 +3431,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -3321,6 +3456,14 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -3830,6 +3973,11 @@ packages:
 
   youch@4.1.1:
     resolution: {integrity: sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -4579,6 +4727,10 @@ snapshots:
 
   '@faker-js/faker@10.4.0': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -4701,6 +4853,28 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -5305,6 +5479,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -5319,12 +5498,23 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -5375,6 +5565,20 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   brace-expansion@1.1.14:
     dependencies:
@@ -5483,10 +5687,6 @@ snapshots:
 
   ci-info@4.4.0: {}
 
-  citty@0.1.6:
-    dependencies:
-      consola: 3.4.2
-
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -5550,11 +5750,20 @@ snapshots:
 
   cookie-es@3.1.1: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookiejar@2.1.4: {}
 
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cron-parser@4.9.0:
     dependencies:
@@ -5732,6 +5941,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
@@ -5903,6 +6114,10 @@ snapshots:
 
   eventsource-parser@3.0.8: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
@@ -5919,6 +6134,44 @@ snapshots:
       yoctocolors: 2.1.2
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extendable-error@0.1.7: {}
 
@@ -5941,6 +6194,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.1.0: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -5972,6 +6227,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-cache-directory@6.0.0:
     dependencies:
@@ -6022,6 +6288,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -6116,6 +6384,8 @@ snapshots:
 
   help-me@5.0.0: {}
 
+  hono@4.12.15: {}
+
   hosted-git-info@9.0.2:
     dependencies:
       lru-cache: 11.3.5
@@ -6187,6 +6457,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ip-address@10.1.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-builtin-module@5.0.0:
@@ -6223,6 +6495,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-promise@4.0.0: {}
+
   is-stream@4.0.1: {}
 
   is-subdir@1.2.0:
@@ -6246,6 +6520,8 @@ snapshots:
       chalk: 4.1.2
       pretty-format: 30.3.0
 
+  jose@6.2.3: {}
+
   joycon@3.1.1: {}
 
   js-sha256@0.11.1: {}
@@ -6266,6 +6542,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -6425,6 +6705,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   methods@1.1.2: {}
@@ -6498,6 +6780,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   nock@14.0.13:
     dependencies:
@@ -6614,6 +6898,8 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parseurl@1.3.3: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -6623,6 +6909,8 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -6724,6 +7012,8 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pkce-challenge@5.0.1: {}
+
   pkg-dir@8.0.0:
     dependencies:
       find-up-simple: 1.0.1
@@ -6816,6 +7106,8 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  range-parser@1.2.1: {}
+
   raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
@@ -6869,6 +7161,8 @@ snapshots:
   regjsparser@0.13.1:
     dependencies:
       jsesc: 3.1.0
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -6925,6 +7219,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -6938,6 +7242,31 @@ snapshots:
   secure-json-parse@4.1.0: {}
 
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-cookie-parser@2.7.2: {}
 
@@ -7424,5 +7753,9 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie-es: 3.1.1
       youch-core: 0.3.3
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}


### PR DESCRIPTION
## Summary

Introduces the `@stashit/mcp` package — an MCP server exposing stashit bookmarks to AI agents (Claude Desktop, Claude Code, Cursor) via 8 Zod-validated tools, built with full TDD coverage.

## Changes

- `apps/mcp/src/tools.ts` — 8 pure handler functions wrapping `@stashit/api-client`
- `apps/mcp/src/server.ts` — `McpServer` factory registering all 8 tools with Zod input schemas
- `apps/mcp/src/index.ts` — stdio entry point reading `STASHIT_API_URL` + `STASHIT_API_KEY`
- `apps/mcp/src/tools.test.ts` — 18 unit tests (handlers avec mock client)
- `apps/mcp/src/server.test.ts` — 10 tests d'intégration (InMemoryTransport + MCP Client)
- `apps/mcp/package.json` — publiable comme `@stashit/mcp` via `npx @stashit/mcp`
- `apps/mcp/tsconfig.json` + `apps/mcp/tsup.config.ts` — config build
- `pnpm-lock.yaml` — `@modelcontextprotocol/sdk@1.29.0` ajouté

## Test plan

- [x] CI passes
- [x] `STASHIT_API_URL=http://localhost:3333 STASHIT_API_KEY=test node apps/mcp/dist/index.js` démarre et liste 8 outils via un client MCP

Closes #15