### PR TITLE
test(web): validate env at server startup

### DIFF
--- a/apps/web/src/ssr.tsx
+++ b/apps/web/src/ssr.tsx
@@ -1,3 +1,4 @@
+import "./config.ts";
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server";
 import { createRouter } from "./router.tsx";
 

--- a/apps/web/tests/startup-env.test.ts
+++ b/apps/web/tests/startup-env.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("server startup env validation", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("refuses to load the server entry without Stashbox API env vars", async () => {
+    vi.stubEnv("STASHBOX_API_URL", undefined);
+    vi.stubEnv("STASHBOX_API_KEY", undefined);
+    vi.resetModules();
+
+    await expect(import("~/ssr.tsx")).rejects.toThrow(
+      "Missing required env vars: STASHBOX_API_URL, STASHBOX_API_KEY",
+    );
+  });
+});


### PR DESCRIPTION
Closes #33

## Summary

- Add coverage proving the TanStack Start server entry refuses to load without `STASHBOX_API_URL` and `STASHBOX_API_KEY`.
- Load the server env config from the SSR entry so missing Stashbox API credentials fail fast.

## Test plan

- [x] `pnpm --filter @stashbox/web test`
- [x] `pnpm --filter @stashbox/web typecheck`
- [x] `STASHBOX_API_URL=http://localhost:3337 STASHBOX_API_KEY=test-key pnpm --filter @stashbox/web build`
- [x] `STASHBOX_API_URL=http://localhost:3337 STASHBOX_API_KEY=test-key pnpm --filter @stashbox/web test:e2e`