### PR TITLE
feat(web): add Stashbox server functions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@stashbox/api-client": "workspace:*",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/server/stashbox.ts
+++ b/apps/web/src/server/stashbox.ts
@@ -1,38 +1,69 @@
 import { StashboxClient } from "@stashbox/api-client";
 import type { AddParams, ListParams, SearchParams } from "@stashbox/api-client";
-import { createServerFn } from "@tanstack/react-start";
+import { createServerFn, serverOnly } from "@tanstack/react-start";
+import { z } from "zod";
 import { env } from "../config.ts";
 
 type ClientOptions = {
   fetch?: typeof globalThis.fetch;
 };
 
-type ServerFnBuilderWithRuntimeHandler<TData, TResponse> = {
-  handler: (
-    extractedFn: undefined,
-    serverFn: (ctx: { data: TData }) => Promise<TResponse>,
-  ) => unknown;
-};
+const bookmarkTypeSchema = z.enum(["tweet", "youtube", "article", "image", "pdf", "other"]);
 
-type ServerFunction<TData, TResponse> = {
-  (opts: { data: TData }): Promise<TResponse>;
-  __executeServer(opts: {
-    method: "GET" | "POST";
-    data: TData;
-    signal: AbortSignal;
-  }): Promise<{ result: TResponse; error: unknown; context: unknown }>;
-};
+const listBookmarksSchema = z
+  .object({
+    limit: z.number().int().positive().max(100).optional(),
+    offset: z.number().int().nonnegative().optional(),
+    type: bookmarkTypeSchema.optional(),
+    tag: z.string().min(1).max(100).optional(),
+  })
+  .default({});
+
+const searchBookmarksSchema = z.object({
+  query: z.string().min(1).max(1_000),
+  limit: z.number().int().positive().max(100).optional(),
+  type: bookmarkTypeSchema.optional(),
+  minScore: z.number().min(0).max(1).optional(),
+  tags: z.array(z.string().min(1).max(100)).max(20).optional(),
+});
+
+const addBookmarkSchema = z.object({
+  url: z
+    .string()
+    .url()
+    .refine((value) => ["http:", "https:"].includes(new URL(value).protocol), {
+      message: "URL must use http or https",
+    }),
+  content: z.string().max(200_000).optional(),
+});
+
+const deleteBookmarkSchema = z.object({
+  id: z.string().uuid(),
+});
 
 let client: StashboxClient | undefined;
 
-export function getStashboxServerClient(options: ClientOptions = {}): StashboxClient {
+export const getStashboxServerClient = serverOnly((options: ClientOptions = {}): StashboxClient => {
   if (options.fetch) {
     return createClient(options.fetch);
   }
 
   client ??= createClient();
   return client;
-}
+});
+
+export const createStashboxServerOperations = serverOnly((client = getStashboxServerClient()) => {
+  return {
+    listBookmarks: async (params: ListParams = {}) =>
+      client.list(listBookmarksSchema.parse(params)),
+    searchBookmarks: async (params: SearchParams) =>
+      client.search(searchBookmarksSchema.parse(params)),
+    addBookmark: async (params: AddParams) => client.add(addBookmarkSchema.parse(params)),
+    deleteBookmark: async ({ id }: { id: string }) =>
+      client.delete(deleteBookmarkSchema.parse({ id }).id),
+    listTags: async () => client.tags(),
+  };
+});
 
 function createClient(fetch?: typeof globalThis.fetch): StashboxClient {
   return new StashboxClient({
@@ -42,55 +73,28 @@ function createClient(fetch?: typeof globalThis.fetch): StashboxClient {
   });
 }
 
-function withServerHandler<TData, TResponse>(
-  builder: { handler: unknown },
-  serverFn: (ctx: { data: TData }) => Promise<TResponse>,
-): ServerFunction<TData, TResponse> {
-  return (builder.handler as ServerFnBuilderWithRuntimeHandler<TData, TResponse>["handler"])(
-    undefined,
-    serverFn,
-  ) as ServerFunction<TData, TResponse>;
-}
+export const listBookmarks = createServerFn({ method: "GET" })
+  .validator((data: ListParams = {}) => listBookmarksSchema.parse(data))
+  .type("dynamic")
+  .handler(async ({ data }): Promise<any> => createStashboxServerOperations().listBookmarks(data));
 
-const listBookmarksBuilder = createServerFn({ method: "GET" })
-  .validator((data: ListParams = {}) => data)
-  .type("dynamic");
+export const searchBookmarks = createServerFn({ method: "POST" })
+  .validator((data: SearchParams) => searchBookmarksSchema.parse(data))
+  .type("dynamic")
+  .handler(
+    async ({ data }): Promise<any> => createStashboxServerOperations().searchBookmarks(data),
+  );
 
-export const listBookmarks = withServerHandler<
-  ListParams,
-  Awaited<ReturnType<StashboxClient["list"]>>
->(listBookmarksBuilder, async ({ data }) => getStashboxServerClient().list(data));
+export const addBookmark = createServerFn({ method: "POST" })
+  .validator((data: AddParams) => addBookmarkSchema.parse(data))
+  .type("dynamic")
+  .handler(async ({ data }): Promise<any> => createStashboxServerOperations().addBookmark(data));
 
-const searchBookmarksBuilder = createServerFn({ method: "POST" })
-  .validator((data: SearchParams) => data)
-  .type("dynamic");
+export const deleteBookmark = createServerFn({ method: "POST" })
+  .validator((data: { id: string }) => deleteBookmarkSchema.parse(data))
+  .type("dynamic")
+  .handler(async ({ data }) => createStashboxServerOperations().deleteBookmark(data));
 
-export const searchBookmarks = withServerHandler<
-  SearchParams,
-  Awaited<ReturnType<StashboxClient["search"]>>
->(searchBookmarksBuilder, async ({ data }) => getStashboxServerClient().search(data));
-
-const addBookmarkBuilder = createServerFn({ method: "POST" })
-  .validator((data: AddParams) => data)
-  .type("dynamic");
-
-export const addBookmark = withServerHandler<AddParams, Awaited<ReturnType<StashboxClient["add"]>>>(
-  addBookmarkBuilder,
-  async ({ data }) => getStashboxServerClient().add(data),
-);
-
-const deleteBookmarkBuilder = createServerFn({ method: "POST" })
-  .validator((data: { id: string }) => data)
-  .type("dynamic");
-
-export const deleteBookmark = withServerHandler<
-  { id: string },
-  Awaited<ReturnType<StashboxClient["delete"]>>
->(deleteBookmarkBuilder, async ({ data }) => getStashboxServerClient().delete(data.id));
-
-const listTagsBuilder = createServerFn({ method: "GET" }).type("dynamic");
-
-export const listTags = withServerHandler<undefined, Awaited<ReturnType<StashboxClient["tags"]>>>(
-  listTagsBuilder,
-  async () => getStashboxServerClient().tags(),
-);
+export const listTags = createServerFn({ method: "GET" })
+  .type("dynamic")
+  .handler(async () => createStashboxServerOperations().listTags());

--- a/apps/web/src/server/stashbox.ts
+++ b/apps/web/src/server/stashbox.ts
@@ -1,0 +1,96 @@
+import { StashboxClient } from "@stashbox/api-client";
+import type { AddParams, ListParams, SearchParams } from "@stashbox/api-client";
+import { createServerFn } from "@tanstack/react-start";
+import { env } from "../config.ts";
+
+type ClientOptions = {
+  fetch?: typeof globalThis.fetch;
+};
+
+type ServerFnBuilderWithRuntimeHandler<TData, TResponse> = {
+  handler: (
+    extractedFn: undefined,
+    serverFn: (ctx: { data: TData }) => Promise<TResponse>,
+  ) => unknown;
+};
+
+type ServerFunction<TData, TResponse> = {
+  (opts: { data: TData }): Promise<TResponse>;
+  __executeServer(opts: {
+    method: "GET" | "POST";
+    data: TData;
+    signal: AbortSignal;
+  }): Promise<{ result: TResponse; error: unknown; context: unknown }>;
+};
+
+let client: StashboxClient | undefined;
+
+export function getStashboxServerClient(options: ClientOptions = {}): StashboxClient {
+  if (options.fetch) {
+    return createClient(options.fetch);
+  }
+
+  client ??= createClient();
+  return client;
+}
+
+function createClient(fetch?: typeof globalThis.fetch): StashboxClient {
+  return new StashboxClient({
+    baseUrl: env.STASHBOX_API_URL,
+    apiKey: env.STASHBOX_API_KEY,
+    fetch,
+  });
+}
+
+function withServerHandler<TData, TResponse>(
+  builder: { handler: unknown },
+  serverFn: (ctx: { data: TData }) => Promise<TResponse>,
+): ServerFunction<TData, TResponse> {
+  return (builder.handler as ServerFnBuilderWithRuntimeHandler<TData, TResponse>["handler"])(
+    undefined,
+    serverFn,
+  ) as ServerFunction<TData, TResponse>;
+}
+
+const listBookmarksBuilder = createServerFn({ method: "GET" })
+  .validator((data: ListParams = {}) => data)
+  .type("dynamic");
+
+export const listBookmarks = withServerHandler<
+  ListParams,
+  Awaited<ReturnType<StashboxClient["list"]>>
+>(listBookmarksBuilder, async ({ data }) => getStashboxServerClient().list(data));
+
+const searchBookmarksBuilder = createServerFn({ method: "POST" })
+  .validator((data: SearchParams) => data)
+  .type("dynamic");
+
+export const searchBookmarks = withServerHandler<
+  SearchParams,
+  Awaited<ReturnType<StashboxClient["search"]>>
+>(searchBookmarksBuilder, async ({ data }) => getStashboxServerClient().search(data));
+
+const addBookmarkBuilder = createServerFn({ method: "POST" })
+  .validator((data: AddParams) => data)
+  .type("dynamic");
+
+export const addBookmark = withServerHandler<AddParams, Awaited<ReturnType<StashboxClient["add"]>>>(
+  addBookmarkBuilder,
+  async ({ data }) => getStashboxServerClient().add(data),
+);
+
+const deleteBookmarkBuilder = createServerFn({ method: "POST" })
+  .validator((data: { id: string }) => data)
+  .type("dynamic");
+
+export const deleteBookmark = withServerHandler<
+  { id: string },
+  Awaited<ReturnType<StashboxClient["delete"]>>
+>(deleteBookmarkBuilder, async ({ data }) => getStashboxServerClient().delete(data.id));
+
+const listTagsBuilder = createServerFn({ method: "GET" }).type("dynamic");
+
+export const listTags = withServerHandler<undefined, Awaited<ReturnType<StashboxClient["tags"]>>>(
+  listTagsBuilder,
+  async () => getStashboxServerClient().tags(),
+);

--- a/apps/web/tests/stashbox-server-client.test.ts
+++ b/apps/web/tests/stashbox-server-client.test.ts
@@ -47,15 +47,10 @@ describe("Bookmark server functions", () => {
       return Response.json({ results: [bookmark] });
     });
 
-    const { listBookmarks } = await import("~/server/stashbox.ts");
+    const { createStashboxServerOperations } = await import("~/server/stashbox.ts");
+    const operations = createStashboxServerOperations();
 
-    await expect(
-      listBookmarks.__executeServer({
-        method: "GET",
-        data: { limit: 10, offset: 20 },
-        signal: new AbortController().signal,
-      }),
-    ).resolves.toMatchObject({ result: [bookmark], error: undefined });
+    await expect(operations.listBookmarks({ limit: 10, offset: 20 })).resolves.toEqual([bookmark]);
     expect(requests[0]?.url).toBe("https://stashbox.example/bookmarks?limit=10&offset=20");
   });
 
@@ -71,15 +66,16 @@ describe("Bookmark server functions", () => {
       return Response.json({ results: [bookmark] });
     });
 
-    const { searchBookmarks } = await import("~/server/stashbox.ts");
+    const { createStashboxServerOperations } = await import("~/server/stashbox.ts");
+    const operations = createStashboxServerOperations();
 
     await expect(
-      searchBookmarks.__executeServer({
-        method: "POST",
-        data: { query: "systems thinking", type: "article", tags: ["architecture"] },
-        signal: new AbortController().signal,
+      operations.searchBookmarks({
+        query: "systems thinking",
+        type: "article",
+        tags: ["architecture"],
       }),
-    ).resolves.toMatchObject({ result: [bookmark], error: undefined });
+    ).resolves.toEqual([bookmark]);
     expect(requests[0]?.url).toBe("https://stashbox.example/search");
     expect(requests[0]?.init?.method).toBe("POST");
     expect(JSON.parse(String(requests[0]?.init?.body))).toEqual({
@@ -101,17 +97,31 @@ describe("Bookmark server functions", () => {
       return Response.json(bookmark);
     });
 
-    const { addBookmark } = await import("~/server/stashbox.ts");
+    const { createStashboxServerOperations } = await import("~/server/stashbox.ts");
+    const operations = createStashboxServerOperations();
 
-    await expect(
-      addBookmark.__executeServer({
-        method: "POST",
-        data: { url: "https://example.com/new" },
-        signal: new AbortController().signal,
-      }),
-    ).resolves.toMatchObject({ result: bookmark, error: undefined });
+    await expect(operations.addBookmark({ url: "https://example.com/new" })).resolves.toEqual(
+      bookmark,
+    );
     expect(requests[0]?.url).toBe("https://stashbox.example/bookmarks");
     expect(JSON.parse(String(requests[0]?.init?.body))).toEqual({ url: "https://example.com/new" });
+  });
+
+  it("rejects non-http Bookmark URLs before calling the Stashbox API", async () => {
+    vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
+    vi.stubEnv("STASHBOX_API_KEY", "secret-key");
+    vi.resetModules();
+
+    const fetch = vi.fn<typeof globalThis.fetch>();
+    vi.stubGlobal("fetch", fetch);
+
+    const { createStashboxServerOperations } = await import("~/server/stashbox.ts");
+    const operations = createStashboxServerOperations();
+
+    await expect(operations.addBookmark({ url: "javascript:alert(1)" })).rejects.toThrow(
+      "URL must use http or https",
+    );
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("deletes a Bookmark through the server-side Stashbox API client", async () => {
@@ -125,15 +135,12 @@ describe("Bookmark server functions", () => {
       return new Response(null, { status: 204 });
     });
 
-    const { deleteBookmark } = await import("~/server/stashbox.ts");
+    const { createStashboxServerOperations } = await import("~/server/stashbox.ts");
+    const operations = createStashboxServerOperations();
 
     await expect(
-      deleteBookmark.__executeServer({
-        method: "POST",
-        data: { id: "00000000-0000-4000-8000-000000000001" },
-        signal: new AbortController().signal,
-      }),
-    ).resolves.toMatchObject({ result: undefined, error: undefined });
+      operations.deleteBookmark({ id: "00000000-0000-4000-8000-000000000001" }),
+    ).resolves.toBeUndefined();
     expect(requests[0]?.url).toBe(
       "https://stashbox.example/bookmarks/00000000-0000-4000-8000-000000000001",
     );
@@ -152,15 +159,10 @@ describe("Bookmark server functions", () => {
       return Response.json({ results: tags });
     });
 
-    const { listTags } = await import("~/server/stashbox.ts");
+    const { createStashboxServerOperations } = await import("~/server/stashbox.ts");
+    const operations = createStashboxServerOperations();
 
-    await expect(
-      listTags.__executeServer({
-        method: "GET",
-        data: undefined,
-        signal: new AbortController().signal,
-      }),
-    ).resolves.toMatchObject({ result: tags, error: undefined });
+    await expect(operations.listTags()).resolves.toEqual(tags);
     expect(requests[0]?.url).toBe("https://stashbox.example/tags");
   });
 });

--- a/apps/web/tests/stashbox-server-client.test.ts
+++ b/apps/web/tests/stashbox-server-client.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("StashboxServerClient", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the Stashbox API env vars for server-side requests", async () => {
+    vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
+    vi.stubEnv("STASHBOX_API_KEY", "secret-key");
+    vi.resetModules();
+
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetch: typeof globalThis.fetch = async (url, init) => {
+      requests.push({ url: String(url), init });
+      return Response.json({ results: [] });
+    };
+
+    const { getStashboxServerClient } = await import("~/server/stashbox.ts");
+    const client = getStashboxServerClient({ fetch });
+
+    await client.list({ limit: 12, offset: 24 });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://stashbox.example/bookmarks?limit=12&offset=24");
+    expect(requests[0]?.init?.headers).toMatchObject({
+      Authorization: "Bearer secret-key",
+    });
+  });
+});
+
+describe("Bookmark server functions", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("lists Bookmarks through the server-side Stashbox API client", async () => {
+    vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
+    vi.stubEnv("STASHBOX_API_KEY", "secret-key");
+    vi.resetModules();
+
+    const bookmark = createBookmark({ title: "Readable systems" });
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Response.json({ results: [bookmark] });
+    });
+
+    const { listBookmarks } = await import("~/server/stashbox.ts");
+
+    await expect(
+      listBookmarks.__executeServer({
+        method: "GET",
+        data: { limit: 10, offset: 20 },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({ result: [bookmark], error: undefined });
+    expect(requests[0]?.url).toBe("https://stashbox.example/bookmarks?limit=10&offset=20");
+  });
+
+  it("searches Bookmarks through the server-side Stashbox API client", async () => {
+    vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
+    vi.stubEnv("STASHBOX_API_KEY", "secret-key");
+    vi.resetModules();
+
+    const bookmark = createBookmark({ title: "Semantic systems" });
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Response.json({ results: [bookmark] });
+    });
+
+    const { searchBookmarks } = await import("~/server/stashbox.ts");
+
+    await expect(
+      searchBookmarks.__executeServer({
+        method: "POST",
+        data: { query: "systems thinking", type: "article", tags: ["architecture"] },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({ result: [bookmark], error: undefined });
+    expect(requests[0]?.url).toBe("https://stashbox.example/search");
+    expect(requests[0]?.init?.method).toBe("POST");
+    expect(JSON.parse(String(requests[0]?.init?.body))).toEqual({
+      query: "systems thinking",
+      type: "article",
+      tags: ["architecture"],
+    });
+  });
+
+  it("adds a Bookmark through the server-side Stashbox API client", async () => {
+    vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
+    vi.stubEnv("STASHBOX_API_KEY", "secret-key");
+    vi.resetModules();
+
+    const bookmark = createBookmark({ url: "https://example.com/new" });
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Response.json(bookmark);
+    });
+
+    const { addBookmark } = await import("~/server/stashbox.ts");
+
+    await expect(
+      addBookmark.__executeServer({
+        method: "POST",
+        data: { url: "https://example.com/new" },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({ result: bookmark, error: undefined });
+    expect(requests[0]?.url).toBe("https://stashbox.example/bookmarks");
+    expect(JSON.parse(String(requests[0]?.init?.body))).toEqual({ url: "https://example.com/new" });
+  });
+
+  it("deletes a Bookmark through the server-side Stashbox API client", async () => {
+    vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
+    vi.stubEnv("STASHBOX_API_KEY", "secret-key");
+    vi.resetModules();
+
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return new Response(null, { status: 204 });
+    });
+
+    const { deleteBookmark } = await import("~/server/stashbox.ts");
+
+    await expect(
+      deleteBookmark.__executeServer({
+        method: "POST",
+        data: { id: "00000000-0000-4000-8000-000000000001" },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({ result: undefined, error: undefined });
+    expect(requests[0]?.url).toBe(
+      "https://stashbox.example/bookmarks/00000000-0000-4000-8000-000000000001",
+    );
+    expect(requests[0]?.init?.method).toBe("DELETE");
+  });
+
+  it("lists Tags through the server-side Stashbox API client", async () => {
+    vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
+    vi.stubEnv("STASHBOX_API_KEY", "secret-key");
+    vi.resetModules();
+
+    const tags = [{ tag: "architecture", count: 3 }];
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Response.json({ results: tags });
+    });
+
+    const { listTags } = await import("~/server/stashbox.ts");
+
+    await expect(
+      listTags.__executeServer({
+        method: "GET",
+        data: undefined,
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({ result: tags, error: undefined });
+    expect(requests[0]?.url).toBe("https://stashbox.example/tags");
+  });
+});
+
+function createBookmark(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    url: "https://example.com/readable-systems",
+    urlHash: "a".repeat(64),
+    type: "article",
+    title: "Readable systems",
+    description: "A useful article",
+    tags: ["architecture"],
+    embedding: null,
+    ogImage: null,
+    embedData: null,
+    enrichmentStatus: "done",
+    enrichmentError: null,
+    enrichmentFailureReason: null,
+    enrichmentAttempts: 1,
+    enrichedAt: "2026-05-06T06:00:00.000Z",
+    embeddingSourceText: "Readable systems / article",
+    savedAt: "2026-05-06T06:00:00.000Z",
+    savedCount: 1,
+    lastSavedAt: "2026-05-06T06:00:00.000Z",
+    savedFrom: ["api"],
+    ...overrides,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
+      '@stashbox/api-client':
+        specifier: workspace:*
+        version: link:../../packages/api-client
       '@tanstack/react-router':
         specifier: 1.131.50
         version: 1.131.50(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
Closes #34

## Summary

- Add a server-only Stashbox API client for the web app.
- Add TanStack Start server functions for listing, searching, adding, deleting Bookmarks, and listing Tags.
- Cover the server-side API path with TDD tests and verify the API key stays out of the client bundle.

## Test plan

- [x] `pnpm --filter @stashbox/web test`
- [x] `pnpm --filter @stashbox/web typecheck`
- [x] `STASHBOX_API_URL=http://localhost:3337 STASHBOX_API_KEY=__STASHBOX_SECRET_SENTINEL__ pnpm --filter @stashbox/web build`
- [x] Client bundle search for `__STASHBOX_SECRET_SENTINEL__` returned no matches
- [x] `STASHBOX_API_URL=http://localhost:3337 STASHBOX_API_KEY=test-key pnpm --filter @stashbox/web test:e2e`