### PR TITLE
feat(web): add Bookmark grid

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@stashbox/api-client": "workspace:*",
+    "@stashbox/shared": "workspace:*",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
@@ -1,0 +1,40 @@
+import type { Bookmark } from "@stashbox/shared";
+
+import { BookmarkGrid } from "./bookmark-grid.tsx";
+
+type BookmarkBrowsePageProps = {
+  bookmarks: Bookmark[];
+  loadError?: string;
+};
+
+export function BookmarkBrowsePage({ bookmarks, loadError }: BookmarkBrowsePageProps) {
+  const countLabel = bookmarks.length === 1 ? "1 Bookmark" : `${bookmarks.length} Bookmarks`;
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-8 text-slate-950 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <header className="space-y-2">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">Bookmarks</p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-4xl font-semibold tracking-tight">Stashbox</h1>
+              <p className="mt-2 max-w-2xl text-sm text-slate-600">
+                Parcourez votre corpus sauvegardé avec son contexte d'enrichissement.
+              </p>
+            </div>
+            <p className="text-sm text-slate-500">{countLabel}</p>
+          </div>
+          {loadError ? (
+            <p
+              role="alert"
+              className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+            >
+              {loadError}
+            </p>
+          ) : null}
+        </header>
+        <BookmarkGrid bookmarks={bookmarks} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/bookmarks/bookmark-card.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-card.tsx
@@ -1,0 +1,40 @@
+import type { Bookmark } from "@stashbox/shared";
+
+type BookmarkCardProps = {
+  bookmark: Bookmark;
+};
+
+export function BookmarkCard({ bookmark }: BookmarkCardProps) {
+  const domain = getDomain(bookmark.url);
+
+  return (
+    <article
+      aria-label={bookmark.title}
+      className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
+    >
+      <div className="aspect-[16/10] bg-slate-100">
+        {bookmark.ogImage ? (
+          <img className="h-full w-full object-cover" src={bookmark.ogImage} alt="" />
+        ) : null}
+      </div>
+      <div className="space-y-3 p-4">
+        <div className="flex items-center justify-between gap-3 text-xs text-slate-500">
+          <span>{domain}</span>
+          <span className="rounded-full bg-slate-900 px-2 py-1 text-white">{bookmark.type}</span>
+        </div>
+        <h2 className="text-base font-semibold text-slate-950">{bookmark.title}</h2>
+        <div className="flex flex-wrap gap-2">
+          {bookmark.tags.map((tag) => (
+            <span key={tag} className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-700">
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function getDomain(url: string) {
+  return new URL(url).hostname.replace(/^www\./, "");
+}

--- a/apps/web/src/components/bookmarks/bookmark-card.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-card.tsx
@@ -6,6 +6,8 @@ type BookmarkCardProps = {
 
 export function BookmarkCard({ bookmark }: BookmarkCardProps) {
   const domain = getDomain(bookmark.url);
+  const isLoading =
+    bookmark.enrichmentStatus === "pending" || bookmark.enrichmentStatus === "enriching";
 
   return (
     <article
@@ -13,19 +15,57 @@ export function BookmarkCard({ bookmark }: BookmarkCardProps) {
       className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
     >
       <div className="aspect-[16/10] bg-slate-100">
-        {bookmark.ogImage ? (
-          <img className="h-full w-full object-cover" src={bookmark.ogImage} alt="" />
-        ) : null}
+        {isLoading ? (
+          <div
+            role="status"
+            aria-label="Enrichissement en cours"
+            className="flex h-full w-full items-center justify-center bg-slate-100"
+          >
+            <span className="h-12 w-12 rounded-full bg-slate-200" />
+          </div>
+        ) : bookmark.enrichmentStatus === "failed" ? (
+          <div
+            role="img"
+            aria-label={`Enrichissement échoué pour ${domain}`}
+            className="flex h-full w-full items-center justify-center bg-rose-50 text-5xl font-semibold text-rose-500"
+          >
+            !
+          </div>
+        ) : bookmark.ogImage ? (
+          <img
+            className="h-full w-full object-cover"
+            src={bookmark.ogImage}
+            alt={`Aperçu de ${bookmark.title}`}
+          />
+        ) : (
+          <div
+            role="img"
+            aria-label={`Aperçu indisponible pour ${domain}`}
+            className="flex h-full w-full items-center justify-center bg-slate-100 text-4xl font-semibold text-slate-400"
+          >
+            {domain.at(0)?.toUpperCase() ?? bookmark.type.at(0)?.toUpperCase()}
+          </div>
+        )}
       </div>
       <div className="space-y-3 p-4">
         <div className="flex items-center justify-between gap-3 text-xs text-slate-500">
-          <span>{domain}</span>
-          <span className="rounded-full bg-slate-900 px-2 py-1 text-white">{bookmark.type}</span>
+          <span className="min-w-0 truncate">{domain}</span>
+          <div className="flex items-center gap-2">
+            {bookmark.enrichmentStatus !== "done" ? (
+              <span className="rounded-full bg-amber-100 px-2 py-1 text-amber-800">
+                {getStatusLabel(bookmark.enrichmentStatus)}
+              </span>
+            ) : null}
+            <span className="rounded-full bg-slate-900 px-2 py-1 text-white">{bookmark.type}</span>
+          </div>
         </div>
         <h2 className="text-base font-semibold text-slate-950">{bookmark.title}</h2>
         <div className="flex flex-wrap gap-2">
           {bookmark.tags.map((tag) => (
-            <span key={tag} className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-700">
+            <span
+              key={tag}
+              className="max-w-full truncate rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-700"
+            >
               {tag}
             </span>
           ))}
@@ -36,5 +76,15 @@ export function BookmarkCard({ bookmark }: BookmarkCardProps) {
 }
 
 function getDomain(url: string) {
-  return new URL(url).hostname.replace(/^www\./, "");
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+function getStatusLabel(status: Bookmark["enrichmentStatus"]) {
+  if (status === "degraded") return "Dégradé";
+  if (status === "failed") return "Échec";
+  return "En attente";
 }

--- a/apps/web/src/components/bookmarks/bookmark-grid.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-grid.tsx
@@ -1,0 +1,23 @@
+import type { Bookmark } from "@stashbox/shared";
+
+import { BookmarkCard } from "./bookmark-card.tsx";
+
+type BookmarkGridProps = {
+  bookmarks: Bookmark[];
+};
+
+export function BookmarkGrid({ bookmarks }: BookmarkGridProps) {
+  return (
+    <div
+      role="list"
+      aria-label="Bookmarks"
+      className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+    >
+      {bookmarks.map((bookmark) => (
+        <div key={bookmark.id} role="listitem">
+          <BookmarkCard bookmark={bookmark} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,13 +1,19 @@
+import type { Bookmark } from "@stashbox/shared";
 import { createFileRoute } from "@tanstack/react-router";
 
+import { BookmarkBrowsePage } from "~/components/bookmarks/bookmark-browse-page.tsx";
+import { loadInitialBookmarks } from "~/server/stashbox.ts";
+
 export const Route = createFileRoute("/")({
+  loader: () => loadInitialBookmarks(),
+  errorComponent: () => (
+    <BookmarkBrowsePage bookmarks={[]} loadError="Impossible de charger les Bookmarks." />
+  ),
   component: HomePage,
 });
 
 function HomePage() {
-  return (
-    <main>
-      <h1>Stashbox</h1>
-    </main>
-  );
+  const bookmarks = Route.useLoaderData() as Bookmark[];
+
+  return <BookmarkBrowsePage bookmarks={bookmarks} />;
 }

--- a/apps/web/src/server/stashbox.ts
+++ b/apps/web/src/server/stashbox.ts
@@ -1,7 +1,9 @@
-import { StashboxClient } from "@stashbox/api-client";
 import type { AddParams, ListParams, SearchParams } from "@stashbox/api-client";
+import { StashboxClient } from "@stashbox/api-client";
+import type { Bookmark } from "@stashbox/shared";
 import { createServerFn, serverOnly } from "@tanstack/react-start";
 import { z } from "zod";
+
 import { env } from "../config.ts";
 
 type ClientOptions = {
@@ -41,6 +43,8 @@ const deleteBookmarkSchema = z.object({
   id: z.string().uuid(),
 });
 
+const initialBookmarksPage = { limit: 48, offset: 0 } satisfies ListParams;
+
 let client: StashboxClient | undefined;
 
 export const getStashboxServerClient = serverOnly((options: ClientOptions = {}): StashboxClient => {
@@ -76,19 +80,23 @@ function createClient(fetch?: typeof globalThis.fetch): StashboxClient {
 export const listBookmarks = createServerFn({ method: "GET" })
   .validator((data: ListParams = {}) => listBookmarksSchema.parse(data))
   .type("dynamic")
-  .handler(async ({ data }): Promise<any> => createStashboxServerOperations().listBookmarks(data));
+  .handler(
+    async ({ data }): Promise<unknown> => createStashboxServerOperations().listBookmarks(data),
+  );
 
 export const searchBookmarks = createServerFn({ method: "POST" })
   .validator((data: SearchParams) => searchBookmarksSchema.parse(data))
   .type("dynamic")
   .handler(
-    async ({ data }): Promise<any> => createStashboxServerOperations().searchBookmarks(data),
+    async ({ data }): Promise<unknown> => createStashboxServerOperations().searchBookmarks(data),
   );
 
 export const addBookmark = createServerFn({ method: "POST" })
   .validator((data: AddParams) => addBookmarkSchema.parse(data))
   .type("dynamic")
-  .handler(async ({ data }): Promise<any> => createStashboxServerOperations().addBookmark(data));
+  .handler(
+    async ({ data }): Promise<unknown> => createStashboxServerOperations().addBookmark(data),
+  );
 
 export const deleteBookmark = createServerFn({ method: "POST" })
   .validator((data: { id: string }) => deleteBookmarkSchema.parse(data))
@@ -98,3 +106,10 @@ export const deleteBookmark = createServerFn({ method: "POST" })
 export const listTags = createServerFn({ method: "GET" })
   .type("dynamic")
   .handler(async () => createStashboxServerOperations().listTags());
+
+export async function loadInitialBookmarks() {
+  return (
+    ((await listBookmarks({ data: initialBookmarksPage })) as Bookmark[] | undefined) ??
+    createStashboxServerOperations().listBookmarks(initialBookmarksPage)
+  );
+}

--- a/apps/web/tests/bookmark-browse-page.test.tsx
+++ b/apps/web/tests/bookmark-browse-page.test.tsx
@@ -1,0 +1,62 @@
+import type { Bookmark } from "@stashbox/shared";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BookmarkBrowsePage } from "~/components/bookmarks/bookmark-browse-page.tsx";
+
+describe("BookmarkBrowsePage", () => {
+  it("renders loaded Bookmarks in the browse grid", () => {
+    render(<BookmarkBrowsePage bookmarks={[createBookmark({ title: "Readable systems" })]} />);
+
+    expect(screen.getByRole("heading", { name: "Stashbox" })).toBeInTheDocument();
+    expect(screen.getByText("1 Bookmark"));
+    expect(screen.getByRole("list", { name: "Bookmarks" })).toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Readable systems" })).toBeInTheDocument();
+  });
+
+  it("pluralizes the Bookmark count", () => {
+    render(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({ id: "00000000-0000-4000-8000-000000000001" }),
+          createBookmark({ id: "00000000-0000-4000-8000-000000000002" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("2 Bookmarks")).toBeInTheDocument();
+  });
+
+  it("shows a load error without hiding the page shell", () => {
+    render(<BookmarkBrowsePage bookmarks={[]} loadError="Impossible de charger les Bookmarks." />);
+
+    expect(screen.getByRole("heading", { name: "Stashbox" })).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Impossible de charger les Bookmarks.");
+  });
+});
+
+function createBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    url: "https://example.com/readable-systems",
+    urlHash: "a".repeat(64),
+    type: "article",
+    title: "Readable systems",
+    description: "A useful article",
+    tags: ["architecture"],
+    embedding: null,
+    ogImage: null,
+    embedData: null,
+    enrichmentStatus: "done",
+    enrichmentError: null,
+    enrichmentFailureReason: null,
+    enrichmentAttempts: 1,
+    enrichedAt: "2026-05-06T06:00:00.000Z",
+    embeddingSourceText: "Readable systems / article",
+    savedAt: "2026-05-06T06:00:00.000Z",
+    savedCount: 1,
+    lastSavedAt: "2026-05-06T06:00:00.000Z",
+    savedFrom: ["api"],
+    ...overrides,
+  };
+}

--- a/apps/web/tests/bookmark-card.test.tsx
+++ b/apps/web/tests/bookmark-card.test.tsx
@@ -1,6 +1,7 @@
+import type { Bookmark } from "@stashbox/shared";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Bookmark } from "@stashbox/shared";
+
 import { BookmarkCard } from "~/components/bookmarks/bookmark-card.tsx";
 
 describe("BookmarkCard", () => {
@@ -12,6 +13,75 @@ describe("BookmarkCard", () => {
     expect(screen.getByText("example.com")).toBeInTheDocument();
     expect(screen.getByText("architecture")).toBeInTheDocument();
     expect(screen.getByText("article")).toBeInTheDocument();
+  });
+
+  it("shows the Open Graph thumbnail when available", () => {
+    render(<BookmarkCard bookmark={createBookmark({ ogImage: "https://example.com/og.png" })} />);
+
+    expect(screen.getByRole("img", { name: "Aperçu de Readable systems" })).toHaveAttribute(
+      "src",
+      "https://example.com/og.png",
+    );
+  });
+
+  it("shows a domain fallback when no thumbnail is available", () => {
+    render(<BookmarkCard bookmark={createBookmark({ ogImage: null })} />);
+
+    expect(
+      screen.getByRole("img", { name: "Aperçu indisponible pour example.com" }),
+    ).toHaveTextContent("E");
+  });
+
+  it("shows a loading state while enrichment is pending", () => {
+    render(
+      <BookmarkCard bookmark={createBookmark({ enrichmentStatus: "pending", ogImage: null })} />,
+    );
+
+    expect(screen.getByRole("status", { name: "Enrichissement en cours" })).toBeInTheDocument();
+  });
+
+  it("shows a loading state while enrichment is running", () => {
+    render(
+      <BookmarkCard bookmark={createBookmark({ enrichmentStatus: "enriching", ogImage: null })} />,
+    );
+
+    expect(screen.getByRole("status", { name: "Enrichissement en cours" })).toBeInTheDocument();
+  });
+
+  it("shows a degraded status indicator", () => {
+    render(
+      <BookmarkCard bookmark={createBookmark({ enrichmentStatus: "degraded", ogImage: null })} />,
+    );
+
+    expect(screen.getByText("Dégradé")).toBeInTheDocument();
+  });
+
+  it("keeps the Open Graph thumbnail for degraded Bookmarks when available", () => {
+    render(
+      <BookmarkCard
+        bookmark={createBookmark({
+          enrichmentStatus: "degraded",
+          ogImage: "https://example.com/og.png",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Dégradé")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Aperçu de Readable systems" })).toHaveAttribute(
+      "src",
+      "https://example.com/og.png",
+    );
+  });
+
+  it("shows a distinct failed visual indicator", () => {
+    render(
+      <BookmarkCard bookmark={createBookmark({ enrichmentStatus: "failed", ogImage: null })} />,
+    );
+
+    expect(screen.getByText("Échec")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Enrichissement échoué pour example.com" }),
+    ).toHaveTextContent("!");
   });
 });
 

--- a/apps/web/tests/bookmark-card.test.tsx
+++ b/apps/web/tests/bookmark-card.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Bookmark } from "@stashbox/shared";
+import { BookmarkCard } from "~/components/bookmarks/bookmark-card.tsx";
+
+describe("BookmarkCard", () => {
+  it("shows the Bookmark title, domain, Tags, and Type", () => {
+    render(<BookmarkCard bookmark={createBookmark()} />);
+
+    expect(screen.getByRole("article", { name: /Readable systems/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Readable systems" })).toBeInTheDocument();
+    expect(screen.getByText("example.com")).toBeInTheDocument();
+    expect(screen.getByText("architecture")).toBeInTheDocument();
+    expect(screen.getByText("article")).toBeInTheDocument();
+  });
+});
+
+function createBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    url: "https://example.com/readable-systems",
+    urlHash: "a".repeat(64),
+    type: "article",
+    title: "Readable systems",
+    description: "A useful article",
+    tags: ["architecture", "systems"],
+    embedding: null,
+    ogImage: "https://example.com/image.png",
+    embedData: null,
+    enrichmentStatus: "done",
+    enrichmentError: null,
+    enrichmentFailureReason: null,
+    enrichmentAttempts: 1,
+    enrichedAt: "2026-05-06T06:00:00.000Z",
+    embeddingSourceText: "Readable systems / article",
+    savedAt: "2026-05-06T06:00:00.000Z",
+    savedCount: 1,
+    lastSavedAt: "2026-05-06T06:00:00.000Z",
+    savedFrom: ["api"],
+    ...overrides,
+  };
+}

--- a/apps/web/tests/bookmark-grid.test.tsx
+++ b/apps/web/tests/bookmark-grid.test.tsx
@@ -1,0 +1,49 @@
+import type { Bookmark } from "@stashbox/shared";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BookmarkGrid } from "~/components/bookmarks/bookmark-grid.tsx";
+
+describe("BookmarkGrid", () => {
+  it("renders Bookmark cards in a browse grid", () => {
+    render(
+      <BookmarkGrid
+        bookmarks={[
+          createBookmark({ id: "00000000-0000-4000-8000-000000000001", title: "Readable systems" }),
+          createBookmark({ id: "00000000-0000-4000-8000-000000000002", title: "Semantic notes" }),
+        ]}
+      />,
+    );
+
+    const grid = screen.getByRole("list", { name: "Bookmarks" });
+    expect(grid).toHaveClass("grid-cols-1", "sm:grid-cols-2", "lg:grid-cols-3", "xl:grid-cols-4");
+    expect(within(grid).getByRole("article", { name: "Readable systems" })).toBeInTheDocument();
+    expect(within(grid).getByRole("article", { name: "Semantic notes" })).toBeInTheDocument();
+  });
+});
+
+function createBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    url: "https://example.com/readable-systems",
+    urlHash: "a".repeat(64),
+    type: "article",
+    title: "Readable systems",
+    description: "A useful article",
+    tags: ["architecture"],
+    embedding: null,
+    ogImage: null,
+    embedData: null,
+    enrichmentStatus: "done",
+    enrichmentError: null,
+    enrichmentFailureReason: null,
+    enrichmentAttempts: 1,
+    enrichedAt: "2026-05-06T06:00:00.000Z",
+    embeddingSourceText: "Readable systems / article",
+    savedAt: "2026-05-06T06:00:00.000Z",
+    savedCount: 1,
+    lastSavedAt: "2026-05-06T06:00:00.000Z",
+    savedFrom: ["api"],
+    ...overrides,
+  };
+}

--- a/apps/web/tests/home-route.test.ts
+++ b/apps/web/tests/home-route.test.ts
@@ -1,0 +1,53 @@
+import type { Bookmark } from "@stashbox/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("home route", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("loads the first page of Bookmarks through the server function", async () => {
+    vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
+    vi.stubEnv("STASHBOX_API_KEY", "secret-key");
+    vi.resetModules();
+
+    const bookmark = createBookmark({ title: "Readable systems" });
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Response.json({ results: [bookmark] });
+    });
+
+    const { Route } = await import("~/routes/index.tsx");
+
+    await expect(Route.options.loader?.({} as never)).resolves.toEqual([bookmark]);
+    expect(requests[0]?.url).toBe("https://stashbox.example/bookmarks?limit=48&offset=0");
+  });
+});
+
+function createBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    url: "https://example.com/readable-systems",
+    urlHash: "a".repeat(64),
+    type: "article",
+    title: "Readable systems",
+    description: "A useful article",
+    tags: ["architecture"],
+    embedding: null,
+    ogImage: null,
+    embedData: null,
+    enrichmentStatus: "done",
+    enrichmentError: null,
+    enrichmentFailureReason: null,
+    enrichmentAttempts: 1,
+    enrichedAt: "2026-05-06T06:00:00.000Z",
+    embeddingSourceText: "Readable systems / article",
+    savedAt: "2026-05-06T06:00:00.000Z",
+    savedCount: 1,
+    lastSavedAt: "2026-05-06T06:00:00.000Z",
+    savedFrom: ["api"],
+    ...overrides,
+  };
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,8 +1,15 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import { TanStackStartVitePlugin } from "@tanstack/react-start/plugin/vite";
+import { resolve } from "node:path";
+
 import tailwindcss from "@tailwindcss/vite";
+import { TanStackStartVitePlugin } from "@tanstack/react-start/plugin/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [TanStackStartVitePlugin({ customViteReactPlugin: true }), react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "~": resolve(__dirname, "src"),
+    },
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       '@stashbox/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
+      '@stashbox/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@tanstack/react-router':
         specifier: 1.131.50
         version: 1.131.50(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
Closes #36

## Summary

- Add `BookmarkCard`, `BookmarkGrid`, and browse page components for the web app.
- Render Bookmarks with OG thumbnails, domain fallbacks, Type/Tag chips, and enrichment status states.
- Wire `/` to load the first Bookmark page and render the responsive grid, with an error fallback if loading fails.

## Test plan

- [x] `pnpm --filter @stashbox/web test`
- [x] `pnpm --filter @stashbox/web typecheck`
- [x] Targeted eslint on changed web files
- [x] `STASHBOX_API_URL=http://localhost:3337 STASHBOX_API_KEY=__STASHBOX_SECRET_SENTINEL__ pnpm --filter @stashbox/web build`
- [x] Client bundle search for `__STASHBOX_SECRET_SENTINEL__` returned no matches
- [x] `STASHBOX_API_URL=http://localhost:3337 STASHBOX_API_KEY=test-key pnpm --filter @stashbox/web test:e2e`