### PR TITLE
feat(web): add inline bookmark save card

### DIFF
--- a/apps/web/src/components/bookmarks/add-bookmark-card.tsx
+++ b/apps/web/src/components/bookmarks/add-bookmark-card.tsx
@@ -1,0 +1,83 @@
+import { type FormEvent, useId, useState } from "react";
+
+import { Button } from "~/components/ui/button.tsx";
+
+type AddBookmarkCardProps = {
+  onSaveBookmark: (url: string) => Promise<void>;
+};
+
+export function AddBookmarkCard({ onSaveBookmark }: AddBookmarkCardProps) {
+  const errorId = useId();
+  const [url, setUrl] = useState("");
+  const [error, setError] = useState<string | undefined>();
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const nextUrl = url.trim();
+    if (!isHttpUrl(nextUrl)) {
+      setError("Saisissez une URL valide.");
+      return;
+    }
+
+    setError(undefined);
+    setIsSaving(true);
+    try {
+      await onSaveBookmark(nextUrl);
+      setUrl("");
+    } catch {
+      setError("Impossible de sauvegarder le Bookmark.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <form
+      aria-label="Sauvegarder un Bookmark"
+      className="flex min-h-full flex-col justify-between rounded-2xl border border-dashed border-slate-300 bg-white p-4 shadow-sm"
+      noValidate
+      onSubmit={handleSubmit}
+    >
+      <div className="space-y-3">
+        <div>
+          <p className="text-sm font-semibold text-slate-950">Sauvegarder un Bookmark</p>
+          <p className="mt-1 text-sm text-slate-500">
+            Collez une URL pour lancer l'enrichissement.
+          </p>
+        </div>
+        <label className="block space-y-2 text-sm font-medium text-slate-700">
+          <span>URL du Bookmark</span>
+          <input
+            aria-describedby={error ? errorId : undefined}
+            aria-invalid={error ? true : undefined}
+            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none transition focus:border-slate-900 focus:ring-2 focus:ring-slate-900/10"
+            disabled={isSaving}
+            onChange={(event) => setUrl(event.target.value)}
+            placeholder="https://example.com/article"
+            type="url"
+            value={url}
+          />
+        </label>
+        {error ? (
+          <p id={errorId} role="alert" className="rounded-xl bg-rose-50 p-3 text-sm text-rose-700">
+            {error}
+          </p>
+        ) : null}
+      </div>
+      <Button className="mt-4 w-full" disabled={isSaving} type="submit">
+        {isSaving ? "Sauvegarde..." : "Sauvegarder"}
+      </Button>
+    </form>
+  );
+}
+
+function isHttpUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
@@ -5,9 +5,14 @@ import { BookmarkGrid } from "./bookmark-grid.tsx";
 type BookmarkBrowsePageProps = {
   bookmarks: Bookmark[];
   loadError?: string;
+  onSaveBookmark: (url: string) => Promise<void>;
 };
 
-export function BookmarkBrowsePage({ bookmarks, loadError }: BookmarkBrowsePageProps) {
+export function BookmarkBrowsePage({
+  bookmarks,
+  loadError,
+  onSaveBookmark,
+}: BookmarkBrowsePageProps) {
   const countLabel = bookmarks.length === 1 ? "1 Bookmark" : `${bookmarks.length} Bookmarks`;
 
   return (
@@ -33,7 +38,7 @@ export function BookmarkBrowsePage({ bookmarks, loadError }: BookmarkBrowsePageP
             </p>
           ) : null}
         </header>
-        <BookmarkGrid bookmarks={bookmarks} />
+        <BookmarkGrid bookmarks={bookmarks} onSaveBookmark={onSaveBookmark} />
       </div>
     </main>
   );

--- a/apps/web/src/components/bookmarks/bookmark-grid.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-grid.tsx
@@ -1,18 +1,23 @@
 import type { Bookmark } from "@stashbox/shared";
 
+import { AddBookmarkCard } from "./add-bookmark-card.tsx";
 import { BookmarkCard } from "./bookmark-card.tsx";
 
 type BookmarkGridProps = {
   bookmarks: Bookmark[];
+  onSaveBookmark: (url: string) => Promise<void>;
 };
 
-export function BookmarkGrid({ bookmarks }: BookmarkGridProps) {
+export function BookmarkGrid({ bookmarks, onSaveBookmark }: BookmarkGridProps) {
   return (
     <div
       role="list"
       aria-label="Bookmarks"
       className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
     >
+      <div role="listitem">
+        <AddBookmarkCard onSaveBookmark={onSaveBookmark} />
+      </div>
       {bookmarks.map((bookmark) => (
         <div key={bookmark.id} role="listitem">
           <BookmarkCard bookmark={bookmark} />

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,19 +1,39 @@
 import type { Bookmark } from "@stashbox/shared";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
 
 import { BookmarkBrowsePage } from "~/components/bookmarks/bookmark-browse-page.tsx";
-import { loadInitialBookmarks } from "~/server/stashbox.ts";
+import { addBookmark, loadInitialBookmarks } from "~/server/stashbox.ts";
 
 export const Route = createFileRoute("/")({
   loader: () => loadInitialBookmarks(),
-  errorComponent: () => (
-    <BookmarkBrowsePage bookmarks={[]} loadError="Impossible de charger les Bookmarks." />
-  ),
+  errorComponent: HomeErrorPage,
   component: HomePage,
 });
 
 function HomePage() {
   const bookmarks = Route.useLoaderData() as Bookmark[];
+  const saveBookmark = useSaveBookmark();
 
-  return <BookmarkBrowsePage bookmarks={bookmarks} />;
+  return <BookmarkBrowsePage bookmarks={bookmarks} onSaveBookmark={saveBookmark} />;
+}
+
+function HomeErrorPage() {
+  const saveBookmark = useSaveBookmark();
+
+  return (
+    <BookmarkBrowsePage
+      bookmarks={[]}
+      loadError="Impossible de charger les Bookmarks."
+      onSaveBookmark={saveBookmark}
+    />
+  );
+}
+
+function useSaveBookmark() {
+  const router = useRouter();
+
+  return async (url: string) => {
+    await addBookmark({ data: { url } });
+    await router.invalidate();
+  };
 }

--- a/apps/web/tests/bookmark-browse-page.test.tsx
+++ b/apps/web/tests/bookmark-browse-page.test.tsx
@@ -1,12 +1,17 @@
 import type { Bookmark } from "@stashbox/shared";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 import { BookmarkBrowsePage } from "~/components/bookmarks/bookmark-browse-page.tsx";
 
 describe("BookmarkBrowsePage", () => {
   it("renders loaded Bookmarks in the browse grid", () => {
-    render(<BookmarkBrowsePage bookmarks={[createBookmark({ title: "Readable systems" })]} />);
+    render(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSaveBookmark={async () => {}}
+      />,
+    );
 
     expect(screen.getByRole("heading", { name: "Stashbox" })).toBeInTheDocument();
     expect(screen.getByText("1 Bookmark"));
@@ -21,6 +26,7 @@ describe("BookmarkBrowsePage", () => {
           createBookmark({ id: "00000000-0000-4000-8000-000000000001" }),
           createBookmark({ id: "00000000-0000-4000-8000-000000000002" }),
         ]}
+        onSaveBookmark={async () => {}}
       />,
     );
 
@@ -28,10 +34,95 @@ describe("BookmarkBrowsePage", () => {
   });
 
   it("shows a load error without hiding the page shell", () => {
-    render(<BookmarkBrowsePage bookmarks={[]} loadError="Impossible de charger les Bookmarks." />);
+    render(
+      <BookmarkBrowsePage
+        bookmarks={[]}
+        loadError="Impossible de charger les Bookmarks."
+        onSaveBookmark={async () => {}}
+      />,
+    );
 
     expect(screen.getByRole("heading", { name: "Stashbox" })).toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent("Impossible de charger les Bookmarks.");
+  });
+
+  it("saves a Bookmark URL from the first grid slot and clears the input", async () => {
+    const saveBookmark = vi.fn().mockResolvedValue(undefined);
+    render(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSaveBookmark={saveBookmark}
+      />,
+    );
+
+    const gridItems = within(screen.getByRole("list", { name: "Bookmarks" })).getAllByRole(
+      "listitem",
+    );
+    const addCard = within(gridItems[0]!).getByRole("form", { name: "Sauvegarder un Bookmark" });
+    const input = within(addCard).getByLabelText("URL du Bookmark");
+
+    fireEvent.change(input, { target: { value: "https://example.com/new" } });
+    fireEvent.click(within(addCard).getByRole("button", { name: "Sauvegarder" }));
+
+    await waitFor(() => expect(saveBookmark).toHaveBeenCalledWith("https://example.com/new"));
+    expect(input).toHaveValue("");
+  });
+
+  it("shows an inline error without saving when the Bookmark URL is invalid", () => {
+    const saveBookmark = vi.fn().mockResolvedValue(undefined);
+    render(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
+
+    const addCard = screen.getByRole("form", { name: "Sauvegarder un Bookmark" });
+    const input = within(addCard).getByLabelText("URL du Bookmark");
+    fireEvent.change(input, {
+      target: { value: "not-a-url" },
+    });
+    fireEvent.click(within(addCard).getByRole("button", { name: "Sauvegarder" }));
+
+    expect(within(addCard).getByRole("alert")).toHaveTextContent("Saisissez une URL valide.");
+    expect(input).toHaveAccessibleDescription("Saisissez une URL valide.");
+    expect(saveBookmark).not.toHaveBeenCalled();
+  });
+
+  it("disables the Save controls while the Bookmark is being saved", async () => {
+    let finishSave!: () => void;
+    const saveBookmark = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSave = resolve;
+        }),
+    );
+    render(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
+
+    const addCard = screen.getByRole("form", { name: "Sauvegarder un Bookmark" });
+    const input = within(addCard).getByLabelText("URL du Bookmark");
+    const button = within(addCard).getByRole("button", { name: "Sauvegarder" });
+
+    fireEvent.change(input, { target: { value: "https://example.com/new" } });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(input).toBeDisabled());
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent("Sauvegarde...");
+
+    finishSave();
+    await waitFor(() => expect(input).not.toBeDisabled());
+  });
+
+  it("shows a server error without clearing the Bookmark URL", async () => {
+    const saveBookmark = vi.fn().mockRejectedValue(new Error("API unavailable"));
+    render(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
+
+    const addCard = screen.getByRole("form", { name: "Sauvegarder un Bookmark" });
+    const input = within(addCard).getByLabelText("URL du Bookmark");
+
+    fireEvent.change(input, { target: { value: "https://example.com/new" } });
+    fireEvent.click(within(addCard).getByRole("button", { name: "Sauvegarder" }));
+
+    expect(await within(addCard).findByRole("alert")).toHaveTextContent(
+      "Impossible de sauvegarder le Bookmark.",
+    );
+    expect(input).toHaveValue("https://example.com/new");
   });
 });
 

--- a/apps/web/tests/bookmark-grid.test.tsx
+++ b/apps/web/tests/bookmark-grid.test.tsx
@@ -12,6 +12,7 @@ describe("BookmarkGrid", () => {
           createBookmark({ id: "00000000-0000-4000-8000-000000000001", title: "Readable systems" }),
           createBookmark({ id: "00000000-0000-4000-8000-000000000002", title: "Semantic notes" }),
         ]}
+        onSaveBookmark={async () => {}}
       />,
     );
 


### PR DESCRIPTION
## Summary

Adds an inline Bookmark save card to the web grid so the Owner can submit URLs from the browse page.

## Changes

- `apps/web/src/components/bookmarks/add-bookmark-card.tsx` — adds the inline save form with validation, loading, and error states
- `apps/web/src/components/bookmarks/bookmark-browse-page.tsx` — passes save behavior into the grid
- `apps/web/src/components/bookmarks/bookmark-grid.tsx` — renders the add card as the first grid item
- `apps/web/src/routes/index.tsx` — wires saving through the server function and refreshes the route
- `apps/web/tests/bookmark-browse-page.test.tsx` — covers save, validation, loading, and server error behavior
- `apps/web/tests/bookmark-grid.test.tsx` — updates grid setup for the save handler

## Test plan

- [x] CI passes
- [x] Save a valid Bookmark URL from `/` and verify the grid refreshes after submit