### PR TITLE
feat: add web theme toggle

### DIFF
--- a/apps/web/src/components/bookmarks/add-bookmark-card.tsx
+++ b/apps/web/src/components/bookmarks/add-bookmark-card.tsx
@@ -36,23 +36,25 @@ export function AddBookmarkCard({ onSaveBookmark }: AddBookmarkCardProps) {
   return (
     <form
       aria-label="Sauvegarder un Bookmark"
-      className="flex min-h-full flex-col justify-between rounded-2xl border border-dashed border-slate-300 bg-white p-4 shadow-sm"
+      className="flex min-h-full flex-col justify-between rounded-2xl border border-dashed border-slate-300 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
       noValidate
       onSubmit={handleSubmit}
     >
       <div className="space-y-3">
         <div>
-          <p className="text-sm font-semibold text-slate-950">Sauvegarder un Bookmark</p>
-          <p className="mt-1 text-sm text-slate-500">
+          <p className="text-sm font-semibold text-slate-950 dark:text-slate-50">
+            Sauvegarder un Bookmark
+          </p>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
             Collez une URL pour lancer l'enrichissement.
           </p>
         </div>
-        <label className="block space-y-2 text-sm font-medium text-slate-700">
+        <label className="block space-y-2 text-sm font-medium text-slate-700 dark:text-slate-200">
           <span>URL du Bookmark</span>
           <input
             aria-describedby={error ? errorId : undefined}
             aria-invalid={error ? true : undefined}
-            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none transition focus:border-slate-900 focus:ring-2 focus:ring-slate-900/10"
+            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none transition focus:border-slate-900 focus:ring-2 focus:ring-slate-900/10 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-slate-200 dark:focus:ring-slate-200/10"
             disabled={isSaving}
             onChange={(event) => setUrl(event.target.value)}
             placeholder="https://example.com/article"
@@ -61,7 +63,11 @@ export function AddBookmarkCard({ onSaveBookmark }: AddBookmarkCardProps) {
           />
         </label>
         {error ? (
-          <p id={errorId} role="alert" className="rounded-xl bg-rose-50 p-3 text-sm text-rose-700">
+          <p
+            id={errorId}
+            role="alert"
+            className="rounded-xl bg-rose-50 p-3 text-sm text-rose-700 dark:bg-rose-500/10 dark:text-rose-200"
+          >
             {error}
           </p>
         ) : null}

--- a/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
@@ -1,5 +1,7 @@
 import type { Bookmark } from "@stashbox/shared";
 
+import { ThemeToggle } from "~/components/theme/theme.tsx";
+
 import { BookmarkGrid } from "./bookmark-grid.tsx";
 
 type BookmarkBrowsePageProps = {
@@ -16,23 +18,28 @@ export function BookmarkBrowsePage({
   const countLabel = bookmarks.length === 1 ? "1 Bookmark" : `${bookmarks.length} Bookmarks`;
 
   return (
-    <main className="min-h-screen bg-slate-50 px-4 py-8 text-slate-950 sm:px-6 lg:px-8">
+    <main className="min-h-screen bg-slate-50 px-4 py-8 text-slate-950 dark:bg-slate-950 dark:text-slate-50 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-7xl space-y-8">
         <header className="space-y-2">
-          <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">Bookmarks</p>
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+            Bookmarks
+          </p>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <h1 className="text-4xl font-semibold tracking-tight">Stashbox</h1>
-              <p className="mt-2 max-w-2xl text-sm text-slate-600">
+              <p className="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
                 Parcourez votre corpus sauvegardé avec son contexte d'enrichissement.
               </p>
             </div>
-            <p className="text-sm text-slate-500">{countLabel}</p>
+            <div className="flex items-center gap-3">
+              <p className="text-sm text-slate-500 dark:text-slate-400">{countLabel}</p>
+              <ThemeToggle />
+            </div>
           </div>
           {loadError ? (
             <p
               role="alert"
-              className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+              className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100"
             >
               {loadError}
             </p>

--- a/apps/web/src/components/bookmarks/bookmark-card.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-card.tsx
@@ -12,22 +12,22 @@ export function BookmarkCard({ bookmark }: BookmarkCardProps) {
   return (
     <article
       aria-label={bookmark.title}
-      className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
+      className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900"
     >
-      <div className="aspect-[16/10] bg-slate-100">
+      <div className="aspect-[16/10] bg-slate-100 dark:bg-slate-800">
         {isLoading ? (
           <div
             role="status"
             aria-label="Enrichissement en cours"
-            className="flex h-full w-full items-center justify-center bg-slate-100"
+            className="flex h-full w-full items-center justify-center bg-slate-100 dark:bg-slate-800"
           >
-            <span className="h-12 w-12 rounded-full bg-slate-200" />
+            <span className="h-12 w-12 rounded-full bg-slate-200 dark:bg-slate-700" />
           </div>
         ) : bookmark.enrichmentStatus === "failed" ? (
           <div
             role="img"
             aria-label={`Enrichissement échoué pour ${domain}`}
-            className="flex h-full w-full items-center justify-center bg-rose-50 text-5xl font-semibold text-rose-500"
+            className="flex h-full w-full items-center justify-center bg-rose-50 text-5xl font-semibold text-rose-500 dark:bg-rose-500/10 dark:text-rose-300"
           >
             !
           </div>
@@ -41,30 +41,34 @@ export function BookmarkCard({ bookmark }: BookmarkCardProps) {
           <div
             role="img"
             aria-label={`Aperçu indisponible pour ${domain}`}
-            className="flex h-full w-full items-center justify-center bg-slate-100 text-4xl font-semibold text-slate-400"
+            className="flex h-full w-full items-center justify-center bg-slate-100 text-4xl font-semibold text-slate-400 dark:bg-slate-800 dark:text-slate-500"
           >
             {domain.at(0)?.toUpperCase() ?? bookmark.type.at(0)?.toUpperCase()}
           </div>
         )}
       </div>
       <div className="space-y-3 p-4">
-        <div className="flex items-center justify-between gap-3 text-xs text-slate-500">
+        <div className="flex items-center justify-between gap-3 text-xs text-slate-500 dark:text-slate-400">
           <span className="min-w-0 truncate">{domain}</span>
           <div className="flex items-center gap-2">
             {bookmark.enrichmentStatus !== "done" ? (
-              <span className="rounded-full bg-amber-100 px-2 py-1 text-amber-800">
+              <span className="rounded-full bg-amber-100 px-2 py-1 text-amber-800 dark:bg-amber-500/10 dark:text-amber-200">
                 {getStatusLabel(bookmark.enrichmentStatus)}
               </span>
             ) : null}
-            <span className="rounded-full bg-slate-900 px-2 py-1 text-white">{bookmark.type}</span>
+            <span className="rounded-full bg-slate-900 px-2 py-1 text-white dark:bg-slate-100 dark:text-slate-950">
+              {bookmark.type}
+            </span>
           </div>
         </div>
-        <h2 className="text-base font-semibold text-slate-950">{bookmark.title}</h2>
+        <h2 className="text-base font-semibold text-slate-950 dark:text-slate-50">
+          {bookmark.title}
+        </h2>
         <div className="flex flex-wrap gap-2">
           {bookmark.tags.map((tag) => (
             <span
               key={tag}
-              className="max-w-full truncate rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-700"
+              className="max-w-full truncate rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-700 dark:bg-slate-800 dark:text-slate-300"
             >
               {tag}
             </span>

--- a/apps/web/src/components/theme/theme.tsx
+++ b/apps/web/src/components/theme/theme.tsx
@@ -1,0 +1,118 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { Button } from "~/components/ui/button.tsx";
+
+type Theme = "light" | "dark";
+
+const storageKey = "stashbox-theme";
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+type ThemeProviderProps = {
+  children: ReactNode;
+};
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const preferredTheme = getPreferredTheme();
+    setTheme(preferredTheme);
+    applyTheme(preferredTheme);
+  }, []);
+
+  const selectTheme = useCallback((nextTheme: Theme) => {
+    setTheme(nextTheme);
+    persistTheme(nextTheme);
+    applyTheme(nextTheme);
+  }, []);
+
+  const value = useMemo(() => ({ theme, setTheme: selectTheme }), [selectTheme, theme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  function toggleTheme() {
+    const nextTheme = isDark ? "light" : "dark";
+    setTheme(nextTheme);
+  }
+
+  return (
+    <Button
+      aria-label={isDark ? "Activer le thème clair" : "Activer le thème sombre"}
+      onClick={toggleTheme}
+      type="button"
+      variant="outline"
+      className="border-slate-300 bg-white text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
+    >
+      {isDark ? "Clair" : "Sombre"}
+    </Button>
+  );
+}
+
+function useTheme() {
+  const value = useContext(ThemeContext);
+  if (!value) throw new Error("ThemeToggle must be rendered inside ThemeProvider");
+  return value;
+}
+
+export function themeInitScript() {
+  return `(() => {
+  try {
+    const key = ${JSON.stringify(storageKey)};
+    const stored = localStorage.getItem(key);
+    const theme = stored === "light" || stored === "dark"
+      ? stored
+      : (matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  } catch {
+    document.documentElement.classList.remove("dark");
+  }
+})();`;
+}
+
+function getPreferredTheme(): Theme {
+  if (typeof window === "undefined") return "light";
+
+  const stored = readStoredTheme();
+  if (stored === "light" || stored === "dark") return stored;
+
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function readStoredTheme() {
+  try {
+    return window.localStorage.getItem(storageKey);
+  } catch {
+    return null;
+  }
+}
+
+function persistTheme(theme: Theme) {
+  try {
+    window.localStorage.setItem(storageKey, theme);
+  } catch {
+    // The visible theme still changes when storage is unavailable.
+  }
+}
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle("dark", theme === "dark");
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,5 +1,7 @@
 import { createRootRoute, Outlet } from "@tanstack/react-router";
 
+import { ThemeProvider, themeInitScript } from "~/components/theme/theme.tsx";
+
 export const Route = createRootRoute({
   component: RootLayout,
 });
@@ -11,9 +13,12 @@ function RootLayout() {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Stashbox</title>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript() }} />
       </head>
       <body>
-        <Outlet />
+        <ThemeProvider>
+          <Outlet />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,4 +1,6 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
+
+import "../styles/app.css";
 
 import { ThemeProvider, themeInitScript } from "~/components/theme/theme.tsx";
 
@@ -14,11 +16,13 @@ function RootLayout() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Stashbox</title>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript() }} />
+        <HeadContent />
       </head>
       <body>
         <ThemeProvider>
           <Outlet />
         </ThemeProvider>
+        <Scripts />
       </body>
     </html>
   );

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1,1 +1,3 @@
 @import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));

--- a/apps/web/tests/bookmark-browse-page.test.tsx
+++ b/apps/web/tests/bookmark-browse-page.test.tsx
@@ -1,12 +1,20 @@
 import type { Bookmark } from "@stashbox/shared";
+import type { ReactElement } from "react";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BookmarkBrowsePage } from "~/components/bookmarks/bookmark-browse-page.tsx";
+import { ThemeProvider } from "~/components/theme/theme.tsx";
 
 describe("BookmarkBrowsePage", () => {
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    vi.unstubAllGlobals();
+  });
+
   it("renders loaded Bookmarks in the browse grid", () => {
-    render(
+    renderPage(
       <BookmarkBrowsePage
         bookmarks={[createBookmark({ title: "Readable systems" })]}
         onSaveBookmark={async () => {}}
@@ -20,7 +28,7 @@ describe("BookmarkBrowsePage", () => {
   });
 
   it("pluralizes the Bookmark count", () => {
-    render(
+    renderPage(
       <BookmarkBrowsePage
         bookmarks={[
           createBookmark({ id: "00000000-0000-4000-8000-000000000001" }),
@@ -34,7 +42,7 @@ describe("BookmarkBrowsePage", () => {
   });
 
   it("shows a load error without hiding the page shell", () => {
-    render(
+    renderPage(
       <BookmarkBrowsePage
         bookmarks={[]}
         loadError="Impossible de charger les Bookmarks."
@@ -46,9 +54,47 @@ describe("BookmarkBrowsePage", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Impossible de charger les Bookmarks.");
   });
 
+  it("switches the visible theme from the header", () => {
+    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={async () => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Activer le thème sombre" }));
+
+    expect(document.documentElement).toHaveClass("dark");
+    expect(screen.getByRole("button", { name: "Activer le thème clair" })).toBeInTheDocument();
+  });
+
+  it("keeps the selected theme for the next page load", () => {
+    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={async () => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Activer le thème sombre" }));
+
+    expect(localStorage.getItem("stashbox-theme")).toBe("dark");
+  });
+
+  it("uses the OS dark preference when no theme was selected", async () => {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(prefers-color-scheme: dark)",
+    }));
+
+    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={async () => {}} />);
+
+    await waitFor(() => expect(document.documentElement).toHaveClass("dark"));
+    expect(screen.getByRole("button", { name: "Activer le thème clair" })).toBeInTheDocument();
+  });
+
+  it("restores the stored theme before using the OS preference", async () => {
+    localStorage.setItem("stashbox-theme", "dark");
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+
+    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={async () => {}} />);
+
+    await waitFor(() => expect(document.documentElement).toHaveClass("dark"));
+    expect(screen.getByRole("button", { name: "Activer le thème clair" })).toBeInTheDocument();
+  });
+
   it("saves a Bookmark URL from the first grid slot and clears the input", async () => {
     const saveBookmark = vi.fn().mockResolvedValue(undefined);
-    render(
+    renderPage(
       <BookmarkBrowsePage
         bookmarks={[createBookmark({ title: "Readable systems" })]}
         onSaveBookmark={saveBookmark}
@@ -70,7 +116,7 @@ describe("BookmarkBrowsePage", () => {
 
   it("shows an inline error without saving when the Bookmark URL is invalid", () => {
     const saveBookmark = vi.fn().mockResolvedValue(undefined);
-    render(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
+    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
 
     const addCard = screen.getByRole("form", { name: "Sauvegarder un Bookmark" });
     const input = within(addCard).getByLabelText("URL du Bookmark");
@@ -92,7 +138,7 @@ describe("BookmarkBrowsePage", () => {
           finishSave = resolve;
         }),
     );
-    render(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
+    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
 
     const addCard = screen.getByRole("form", { name: "Sauvegarder un Bookmark" });
     const input = within(addCard).getByLabelText("URL du Bookmark");
@@ -111,7 +157,7 @@ describe("BookmarkBrowsePage", () => {
 
   it("shows a server error without clearing the Bookmark URL", async () => {
     const saveBookmark = vi.fn().mockRejectedValue(new Error("API unavailable"));
-    render(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
+    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
 
     const addCard = screen.getByRole("form", { name: "Sauvegarder un Bookmark" });
     const input = within(addCard).getByLabelText("URL du Bookmark");
@@ -125,6 +171,10 @@ describe("BookmarkBrowsePage", () => {
     expect(input).toHaveValue("https://example.com/new");
   });
 });
+
+function renderPage(page: ReactElement) {
+  return render(<ThemeProvider>{page}</ThemeProvider>);
+}
 
 function createBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
   return {

--- a/apps/web/tests/e2e/root-layout.spec.ts
+++ b/apps/web/tests/e2e/root-layout.spec.ts
@@ -10,5 +10,6 @@ test("root layout renders without error", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.locator("h1")).toContainText("Stashbox");
+  await expect(page.getByRole("list", { name: "Bookmarks" })).toHaveCSS("display", "grid");
   expect(errors).toHaveLength(0);
 });

--- a/apps/web/tests/theme.test.tsx
+++ b/apps/web/tests/theme.test.tsx
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { themeInitScript } from "~/components/theme/theme.tsx";
+
+describe("theme initialization", () => {
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    vi.unstubAllGlobals();
+  });
+
+  it("applies the stored dark theme before React renders", () => {
+    localStorage.setItem("stashbox-theme", "dark");
+
+    Function(themeInitScript())();
+
+    expect(document.documentElement).toHaveClass("dark");
+  });
+
+  it("removes a stale dark class when the stored theme is light", () => {
+    localStorage.setItem("stashbox-theme", "light");
+    document.documentElement.classList.add("dark");
+
+    Function(themeInitScript())();
+
+    expect(document.documentElement).not.toHaveClass("dark");
+  });
+
+  it("uses the OS dark preference before React renders when no theme is stored", () => {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(prefers-color-scheme: dark)",
+    }));
+
+    Function(themeInitScript())();
+
+    expect(document.documentElement).toHaveClass("dark");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev",
+    "dev": "turbo run dev --ui=stream --log-order=stream",
     "lint": "turbo run lint",
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",


### PR DESCRIPTION
## Summary

Adds a persistent light/dark theme toggle to the web app with SSR-safe initial theme application. Closes #35.

## Changes

- `apps/web/src/components/theme/theme.tsx` — add theme provider, toggle, storage, OS fallback, and init script
- `apps/web/src/components/bookmarks/bookmark-browse-page.tsx` — add header theme toggle and dark-mode page styles
- `apps/web/src/components/bookmarks/add-bookmark-card.tsx` — add dark-mode form styles
- `apps/web/src/components/bookmarks/bookmark-card.tsx` — add dark-mode card styles
- `apps/web/src/routes/__root.tsx` — wrap app in ThemeProvider and inject init script
- `apps/web/src/styles/app.css` — enable class-based Tailwind dark variant
- `apps/web/tests/bookmark-browse-page.test.tsx` — cover theme toggle, persistence, and preference restore behavior
- `apps/web/tests/theme.test.tsx` — cover pre-React theme initialization behavior

## Test plan

- [x] CI passes
- [x] Visual check theme toggle on `/` before and after page reload