### PR TITLE
feat: suppression de Bookmark avec dialog

### DIFF
--- a/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
@@ -1,4 +1,5 @@
 import type { Bookmark } from "@stashbox/shared";
+import { useEffect, useState } from "react";
 
 import { ThemeToggle } from "~/components/theme/theme.tsx";
 
@@ -8,14 +9,27 @@ type BookmarkBrowsePageProps = {
   bookmarks: Bookmark[];
   loadError?: string;
   onSaveBookmark: (url: string) => Promise<void>;
+  onDeleteBookmark: (id: string) => Promise<void>;
 };
 
 export function BookmarkBrowsePage({
   bookmarks,
   loadError,
   onSaveBookmark,
+  onDeleteBookmark,
 }: BookmarkBrowsePageProps) {
-  const countLabel = bookmarks.length === 1 ? "1 Bookmark" : `${bookmarks.length} Bookmarks`;
+  const [visibleBookmarks, setVisibleBookmarks] = useState(bookmarks);
+  const countLabel =
+    visibleBookmarks.length === 1 ? "1 Bookmark" : `${visibleBookmarks.length} Bookmarks`;
+
+  useEffect(() => {
+    setVisibleBookmarks(bookmarks);
+  }, [bookmarks]);
+
+  async function handleDeleteBookmark(id: string) {
+    await onDeleteBookmark(id);
+    setVisibleBookmarks((current) => current.filter((bookmark) => bookmark.id !== id));
+  }
 
   return (
     <main className="min-h-screen bg-slate-50 px-4 py-8 text-slate-950 dark:bg-slate-950 dark:text-slate-50 sm:px-6 lg:px-8">
@@ -45,7 +59,11 @@ export function BookmarkBrowsePage({
             </p>
           ) : null}
         </header>
-        <BookmarkGrid bookmarks={bookmarks} onSaveBookmark={onSaveBookmark} />
+        <BookmarkGrid
+          bookmarks={visibleBookmarks}
+          onSaveBookmark={onSaveBookmark}
+          onDeleteBookmark={handleDeleteBookmark}
+        />
       </div>
     </main>
   );

--- a/apps/web/src/components/bookmarks/bookmark-card.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-card.tsx
@@ -1,10 +1,14 @@
 import type { Bookmark } from "@stashbox/shared";
+import { useState } from "react";
 
 type BookmarkCardProps = {
   bookmark: Bookmark;
+  onDeleteBookmark: (id: string) => Promise<void>;
 };
 
-export function BookmarkCard({ bookmark }: BookmarkCardProps) {
+export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) {
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const domain = getDomain(bookmark.url);
   const isLoading =
     bookmark.enrichmentStatus === "pending" || bookmark.enrichmentStatus === "enriching";
@@ -74,7 +78,62 @@ export function BookmarkCard({ bookmark }: BookmarkCardProps) {
             </span>
           ))}
         </div>
+        <button
+          type="button"
+          aria-label={`Supprimer ${bookmark.title}`}
+          onClick={() => setIsConfirmingDelete(true)}
+          className="rounded-full border border-rose-200 px-3 py-1 text-sm font-medium text-rose-700 hover:bg-rose-50 dark:border-rose-500/40 dark:text-rose-200 dark:hover:bg-rose-500/10"
+        >
+          Supprimer
+        </button>
       </div>
+      {isConfirmingDelete ? (
+        <div
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby={`delete-title-${bookmark.id}`}
+          aria-describedby={`delete-description-${bookmark.id}`}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 p-4"
+        >
+          <div className="max-w-sm rounded-2xl border border-slate-200 bg-white p-5 text-slate-950 shadow-xl dark:border-slate-800 dark:bg-slate-900 dark:text-slate-50">
+            <h3 id={`delete-title-${bookmark.id}`} className="text-lg font-semibold">
+              Supprimer ce bookmark ?
+            </h3>
+            <p
+              id={`delete-description-${bookmark.id}`}
+              className="mt-2 text-sm text-slate-600 dark:text-slate-300"
+            >
+              Cette action retirera "{bookmark.title}" de votre grille.
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setIsConfirmingDelete(false)}
+                disabled={isDeleting}
+                className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                onClick={async () => {
+                  setIsDeleting(true);
+                  try {
+                    await onDeleteBookmark(bookmark.id);
+                    setIsConfirmingDelete(false);
+                  } finally {
+                    setIsDeleting(false);
+                  }
+                }}
+                disabled={isDeleting}
+                className="rounded-full bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700"
+              >
+                {isDeleting ? "Suppression..." : "Supprimer"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </article>
   );
 }

--- a/apps/web/src/components/bookmarks/bookmark-grid.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-grid.tsx
@@ -6,9 +6,10 @@ import { BookmarkCard } from "./bookmark-card.tsx";
 type BookmarkGridProps = {
   bookmarks: Bookmark[];
   onSaveBookmark: (url: string) => Promise<void>;
+  onDeleteBookmark: (id: string) => Promise<void>;
 };
 
-export function BookmarkGrid({ bookmarks, onSaveBookmark }: BookmarkGridProps) {
+export function BookmarkGrid({ bookmarks, onSaveBookmark, onDeleteBookmark }: BookmarkGridProps) {
   return (
     <div
       role="list"
@@ -20,7 +21,7 @@ export function BookmarkGrid({ bookmarks, onSaveBookmark }: BookmarkGridProps) {
       </div>
       {bookmarks.map((bookmark) => (
         <div key={bookmark.id} role="listitem">
-          <BookmarkCard bookmark={bookmark} />
+          <BookmarkCard bookmark={bookmark} onDeleteBookmark={onDeleteBookmark} />
         </div>
       ))}
     </div>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,52 +8,52 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as IndexRouteImport } from "./routes/index";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
 
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
+  '/': typeof IndexRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
+  '/': typeof IndexRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/";
-  fileRoutesByTo: FileRoutesByTo;
-  to: "/";
-  id: "__root__" | "/";
-  fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths: '/'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/'
+  id: '__root__' | '/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
+  IndexRoute: typeof IndexRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -2,7 +2,7 @@ import type { Bookmark } from "@stashbox/shared";
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 
 import { BookmarkBrowsePage } from "~/components/bookmarks/bookmark-browse-page.tsx";
-import { addBookmark, loadInitialBookmarks } from "~/server/stashbox.ts";
+import { addBookmark, deleteBookmark, loadInitialBookmarks } from "~/server/stashbox.ts";
 
 export const Route = createFileRoute("/")({
   loader: () => loadInitialBookmarks(),
@@ -13,18 +13,27 @@ export const Route = createFileRoute("/")({
 function HomePage() {
   const bookmarks = Route.useLoaderData() as Bookmark[];
   const saveBookmark = useSaveBookmark();
+  const removeBookmark = useDeleteBookmark();
 
-  return <BookmarkBrowsePage bookmarks={bookmarks} onSaveBookmark={saveBookmark} />;
+  return (
+    <BookmarkBrowsePage
+      bookmarks={bookmarks}
+      onSaveBookmark={saveBookmark}
+      onDeleteBookmark={removeBookmark}
+    />
+  );
 }
 
 function HomeErrorPage() {
   const saveBookmark = useSaveBookmark();
+  const removeBookmark = useDeleteBookmark();
 
   return (
     <BookmarkBrowsePage
       bookmarks={[]}
       loadError="Impossible de charger les Bookmarks."
       onSaveBookmark={saveBookmark}
+      onDeleteBookmark={removeBookmark}
     />
   );
 }
@@ -35,5 +44,11 @@ function useSaveBookmark() {
   return async (url: string) => {
     await addBookmark({ data: { url } });
     await router.invalidate();
+  };
+}
+
+function useDeleteBookmark() {
+  return async (id: string) => {
+    await deleteBookmark({ data: { id } });
   };
 }

--- a/apps/web/tests/bookmark-browse-page.test.tsx
+++ b/apps/web/tests/bookmark-browse-page.test.tsx
@@ -1,6 +1,6 @@
 import type { Bookmark } from "@stashbox/shared";
-import type { ReactElement } from "react";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BookmarkBrowsePage } from "~/components/bookmarks/bookmark-browse-page.tsx";
@@ -18,6 +18,7 @@ describe("BookmarkBrowsePage", () => {
       <BookmarkBrowsePage
         bookmarks={[createBookmark({ title: "Readable systems" })]}
         onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
       />,
     );
 
@@ -35,6 +36,7 @@ describe("BookmarkBrowsePage", () => {
           createBookmark({ id: "00000000-0000-4000-8000-000000000002" }),
         ]}
         onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
       />,
     );
 
@@ -47,6 +49,7 @@ describe("BookmarkBrowsePage", () => {
         bookmarks={[]}
         loadError="Impossible de charger les Bookmarks."
         onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
       />,
     );
 
@@ -55,7 +58,13 @@ describe("BookmarkBrowsePage", () => {
   });
 
   it("switches the visible theme from the header", () => {
-    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={async () => {}} />);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Activer le thème sombre" }));
 
@@ -64,7 +73,13 @@ describe("BookmarkBrowsePage", () => {
   });
 
   it("keeps the selected theme for the next page load", () => {
-    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={async () => {}} />);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Activer le thème sombre" }));
 
@@ -76,7 +91,13 @@ describe("BookmarkBrowsePage", () => {
       matches: query === "(prefers-color-scheme: dark)",
     }));
 
-    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={async () => {}} />);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
 
     await waitFor(() => expect(document.documentElement).toHaveClass("dark"));
     expect(screen.getByRole("button", { name: "Activer le thème clair" })).toBeInTheDocument();
@@ -86,7 +107,13 @@ describe("BookmarkBrowsePage", () => {
     localStorage.setItem("stashbox-theme", "dark");
     vi.stubGlobal("matchMedia", () => ({ matches: false }));
 
-    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={async () => {}} />);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
 
     await waitFor(() => expect(document.documentElement).toHaveClass("dark"));
     expect(screen.getByRole("button", { name: "Activer le thème clair" })).toBeInTheDocument();
@@ -98,6 +125,7 @@ describe("BookmarkBrowsePage", () => {
       <BookmarkBrowsePage
         bookmarks={[createBookmark({ title: "Readable systems" })]}
         onSaveBookmark={saveBookmark}
+        onDeleteBookmark={async () => {}}
       />,
     );
 
@@ -116,7 +144,13 @@ describe("BookmarkBrowsePage", () => {
 
   it("shows an inline error without saving when the Bookmark URL is invalid", () => {
     const saveBookmark = vi.fn().mockResolvedValue(undefined);
-    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[]}
+        onSaveBookmark={saveBookmark}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
 
     const addCard = screen.getByRole("form", { name: "Sauvegarder un Bookmark" });
     const input = within(addCard).getByLabelText("URL du Bookmark");
@@ -138,7 +172,13 @@ describe("BookmarkBrowsePage", () => {
           finishSave = resolve;
         }),
     );
-    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[]}
+        onSaveBookmark={saveBookmark}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
 
     const addCard = screen.getByRole("form", { name: "Sauvegarder un Bookmark" });
     const input = within(addCard).getByLabelText("URL du Bookmark");
@@ -157,7 +197,13 @@ describe("BookmarkBrowsePage", () => {
 
   it("shows a server error without clearing the Bookmark URL", async () => {
     const saveBookmark = vi.fn().mockRejectedValue(new Error("API unavailable"));
-    renderPage(<BookmarkBrowsePage bookmarks={[]} onSaveBookmark={saveBookmark} />);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[]}
+        onSaveBookmark={saveBookmark}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
 
     const addCard = screen.getByRole("form", { name: "Sauvegarder un Bookmark" });
     const input = within(addCard).getByLabelText("URL du Bookmark");
@@ -169,6 +215,97 @@ describe("BookmarkBrowsePage", () => {
       "Impossible de sauvegarder le Bookmark.",
     );
     expect(input).toHaveValue("https://example.com/new");
+  });
+
+  it("keeps the Bookmark when the delete confirmation is cancelled", () => {
+    const deleteBookmark = vi.fn().mockResolvedValue(undefined);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={deleteBookmark}
+      />,
+    );
+
+    const card = screen.getByRole("article", { name: "Readable systems" });
+    fireEvent.click(within(card).getByRole("button", { name: "Supprimer Readable systems" }));
+
+    expect(
+      screen.getByRole("alertdialog", { name: "Supprimer ce bookmark ?" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Annuler" }));
+
+    expect(
+      screen.queryByRole("alertdialog", { name: "Supprimer ce bookmark ?" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Readable systems" })).toBeInTheDocument();
+    expect(deleteBookmark).not.toHaveBeenCalled();
+  });
+
+  it("deletes the Bookmark and removes it from the grid when deletion is confirmed", async () => {
+    const deleteBookmark = vi.fn().mockResolvedValue(undefined);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={deleteBookmark}
+      />,
+    );
+
+    fireEvent.click(
+      within(screen.getByRole("article", { name: "Readable systems" })).getByRole("button", {
+        name: "Supprimer Readable systems",
+      }),
+    );
+    fireEvent.click(
+      within(screen.getByRole("alertdialog", { name: "Supprimer ce bookmark ?" })).getByRole(
+        "button",
+        { name: "Supprimer" },
+      ),
+    );
+
+    await waitFor(() =>
+      expect(deleteBookmark).toHaveBeenCalledWith("00000000-0000-4000-8000-000000000001"),
+    );
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+    expect(screen.getByText("0 Bookmarks")).toBeInTheDocument();
+  });
+
+  it("disables the delete confirmation while deletion is in flight", async () => {
+    let finishDelete!: () => void;
+    const deleteBookmark = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDelete = resolve;
+        }),
+    );
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={deleteBookmark}
+      />,
+    );
+
+    fireEvent.click(
+      within(screen.getByRole("article", { name: "Readable systems" })).getByRole("button", {
+        name: "Supprimer Readable systems",
+      }),
+    );
+    const dialog = screen.getByRole("alertdialog", { name: "Supprimer ce bookmark ?" });
+    const confirmButton = within(dialog).getByRole("button", { name: "Supprimer" });
+
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(confirmButton).toBeDisabled());
+    expect(confirmButton).toHaveTextContent("Suppression...");
+    expect(within(dialog).getByRole("button", { name: "Annuler" })).toBeDisabled();
+
+    finishDelete();
+    await waitFor(() =>
+      expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument(),
+    );
   });
 });
 

--- a/apps/web/tests/bookmark-card.test.tsx
+++ b/apps/web/tests/bookmark-card.test.tsx
@@ -6,7 +6,7 @@ import { BookmarkCard } from "~/components/bookmarks/bookmark-card.tsx";
 
 describe("BookmarkCard", () => {
   it("shows the Bookmark title, domain, Tags, and Type", () => {
-    render(<BookmarkCard bookmark={createBookmark()} />);
+    render(<BookmarkCard bookmark={createBookmark()} onDeleteBookmark={async () => {}} />);
 
     expect(screen.getByRole("article", { name: /Readable systems/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Readable systems" })).toBeInTheDocument();
@@ -16,7 +16,12 @@ describe("BookmarkCard", () => {
   });
 
   it("shows the Open Graph thumbnail when available", () => {
-    render(<BookmarkCard bookmark={createBookmark({ ogImage: "https://example.com/og.png" })} />);
+    render(
+      <BookmarkCard
+        bookmark={createBookmark({ ogImage: "https://example.com/og.png" })}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
 
     expect(screen.getByRole("img", { name: "Aperçu de Readable systems" })).toHaveAttribute(
       "src",
@@ -25,7 +30,12 @@ describe("BookmarkCard", () => {
   });
 
   it("shows a domain fallback when no thumbnail is available", () => {
-    render(<BookmarkCard bookmark={createBookmark({ ogImage: null })} />);
+    render(
+      <BookmarkCard
+        bookmark={createBookmark({ ogImage: null })}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
 
     expect(
       screen.getByRole("img", { name: "Aperçu indisponible pour example.com" }),
@@ -34,7 +44,10 @@ describe("BookmarkCard", () => {
 
   it("shows a loading state while enrichment is pending", () => {
     render(
-      <BookmarkCard bookmark={createBookmark({ enrichmentStatus: "pending", ogImage: null })} />,
+      <BookmarkCard
+        bookmark={createBookmark({ enrichmentStatus: "pending", ogImage: null })}
+        onDeleteBookmark={async () => {}}
+      />,
     );
 
     expect(screen.getByRole("status", { name: "Enrichissement en cours" })).toBeInTheDocument();
@@ -42,7 +55,10 @@ describe("BookmarkCard", () => {
 
   it("shows a loading state while enrichment is running", () => {
     render(
-      <BookmarkCard bookmark={createBookmark({ enrichmentStatus: "enriching", ogImage: null })} />,
+      <BookmarkCard
+        bookmark={createBookmark({ enrichmentStatus: "enriching", ogImage: null })}
+        onDeleteBookmark={async () => {}}
+      />,
     );
 
     expect(screen.getByRole("status", { name: "Enrichissement en cours" })).toBeInTheDocument();
@@ -50,7 +66,10 @@ describe("BookmarkCard", () => {
 
   it("shows a degraded status indicator", () => {
     render(
-      <BookmarkCard bookmark={createBookmark({ enrichmentStatus: "degraded", ogImage: null })} />,
+      <BookmarkCard
+        bookmark={createBookmark({ enrichmentStatus: "degraded", ogImage: null })}
+        onDeleteBookmark={async () => {}}
+      />,
     );
 
     expect(screen.getByText("Dégradé")).toBeInTheDocument();
@@ -63,6 +82,7 @@ describe("BookmarkCard", () => {
           enrichmentStatus: "degraded",
           ogImage: "https://example.com/og.png",
         })}
+        onDeleteBookmark={async () => {}}
       />,
     );
 
@@ -75,7 +95,10 @@ describe("BookmarkCard", () => {
 
   it("shows a distinct failed visual indicator", () => {
     render(
-      <BookmarkCard bookmark={createBookmark({ enrichmentStatus: "failed", ogImage: null })} />,
+      <BookmarkCard
+        bookmark={createBookmark({ enrichmentStatus: "failed", ogImage: null })}
+        onDeleteBookmark={async () => {}}
+      />,
     );
 
     expect(screen.getByText("Échec")).toBeInTheDocument();

--- a/apps/web/tests/bookmark-grid.test.tsx
+++ b/apps/web/tests/bookmark-grid.test.tsx
@@ -13,6 +13,7 @@ describe("BookmarkGrid", () => {
           createBookmark({ id: "00000000-0000-4000-8000-000000000002", title: "Semantic notes" }),
         ]}
         onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
       />,
     );
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,27 @@
+# Issue #38 - Delete Bookmark
+
+## Plan
+
+- [x] RED: prove cancelling the delete confirmation keeps the bookmark and does not call delete.
+- [x] GREEN: add a delete button and confirmation dialog with cancel behavior.
+- [x] RED: prove confirming delete calls the delete action and removes the card without page reload.
+- [x] GREEN: wire `deleteBookmark` through the browse page and update local grid state.
+- [x] RED: prove the delete button is disabled while deletion is in flight.
+- [x] GREEN: add in-flight state and accessible disabled UI.
+- [x] Refactor only after green.
+- [x] Verify with web tests, typecheck, and targeted lint.
+- [ ] Push branch and create draft PR linked with `Closes #38`.
+
+## Scope
+
+- App: `apps/web`.
+- Public interface: user interacts with `BookmarkBrowsePage` / `BookmarkCard`.
+- User-facing copy: French.
+
+## Review
+
+- `pnpm --filter @stashbox/web test` passed: 9 files, 40 tests.
+- `pnpm --filter @stashbox/web typecheck` passed.
+- Targeted ESLint passed on changed web files.
+- Prettier check passed on changed files.
+- Full `pnpm --filter @stashbox/web lint` is blocked by existing generated `app.config.timestamp_*.js` import-sort errors outside this change.


### PR DESCRIPTION
Closes #38

## Summary

- add a delete action to Bookmark cards
- confirm deletion before calling the web server function
- remove deleted Bookmarks from the grid without a full page reload

## Test plan

- [x] pnpm --filter @stashbox/web test
- [x] pnpm --filter @stashbox/web typecheck
- [x] targeted ESLint on changed web files
- [x] Prettier check on changed files
- [x] full pnpm --filter @stashbox/web lint (blocked by existing generated app.config.timestamp_*.js import-sort errors)