### PR TITLE
feat: filter bar tag type et texte

### DIFF
--- a/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
@@ -1,3 +1,4 @@
+import type { Tag } from "@stashbox/api-client";
 import type { Bookmark } from "@stashbox/shared";
 import { useEffect, useState } from "react";
 
@@ -5,8 +6,14 @@ import { ThemeToggle } from "~/components/theme/theme.tsx";
 
 import { BookmarkGrid } from "./bookmark-grid.tsx";
 
+const bookmarkTypes = ["tweet", "youtube", "article", "image", "pdf", "other"] as const;
+const emptyBookmarkFilters: BookmarkFilters = { selectedTags: [], textFilter: "", typeFilter: "" };
+const filterControlClassName =
+  "w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none transition focus:border-slate-900 focus:ring-2 focus:ring-slate-900/10 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-slate-200 dark:focus:ring-slate-200/10";
+
 type BookmarkBrowsePageProps = {
   bookmarks: Bookmark[];
+  tags?: Tag[];
   loadError?: string;
   onSaveBookmark: (url: string) => Promise<void>;
   onDeleteBookmark: (id: string) => Promise<void>;
@@ -14,21 +21,54 @@ type BookmarkBrowsePageProps = {
 
 export function BookmarkBrowsePage({
   bookmarks,
+  tags = [],
   loadError,
   onSaveBookmark,
   onDeleteBookmark,
 }: BookmarkBrowsePageProps) {
   const [visibleBookmarks, setVisibleBookmarks] = useState(bookmarks);
+  const [filters, setFilters] = useState<BookmarkFilters>(emptyBookmarkFilters);
+  const [hasLoadedUrlFilters, setHasLoadedUrlFilters] = useState(false);
+  const filteredBookmarks = filterBookmarks(visibleBookmarks, filters);
   const countLabel =
-    visibleBookmarks.length === 1 ? "1 Bookmark" : `${visibleBookmarks.length} Bookmarks`;
+    filteredBookmarks.length === 1 ? "1 Bookmark" : `${filteredBookmarks.length} Bookmarks`;
+  const hasActiveFilters = hasActiveBookmarkFilters(filters);
 
   useEffect(() => {
     setVisibleBookmarks(bookmarks);
   }, [bookmarks]);
 
+  useEffect(() => {
+    setFilters(getInitialBookmarkFilters());
+    setHasLoadedUrlFilters(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hasLoadedUrlFilters) return;
+
+    syncBookmarkFiltersToUrl(filters);
+  }, [filters, hasLoadedUrlFilters]);
+
   async function handleDeleteBookmark(id: string) {
     await onDeleteBookmark(id);
     setVisibleBookmarks((current) => current.filter((bookmark) => bookmark.id !== id));
+  }
+
+  function toggleTag(tag: string) {
+    setFilters((current) => {
+      if (current.selectedTags.includes(tag)) {
+        return {
+          ...current,
+          selectedTags: current.selectedTags.filter((selectedTag) => selectedTag !== tag),
+        };
+      }
+
+      return { ...current, selectedTags: [...current.selectedTags, tag] };
+    });
+  }
+
+  function clearFilters() {
+    setFilters(emptyBookmarkFilters);
   }
 
   return (
@@ -59,12 +99,176 @@ export function BookmarkBrowsePage({
             </p>
           ) : null}
         </header>
+        <section
+          aria-label="Filtres de Bookmarks"
+          className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+        >
+          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_12rem]">
+            <label className="block space-y-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+              <span>Filtrer par texte</span>
+              <input
+                type="search"
+                value={filters.textFilter}
+                onChange={(event) =>
+                  setFilters((current) => ({ ...current, textFilter: event.target.value }))
+                }
+                placeholder="Titre ou URL"
+                className={filterControlClassName}
+              />
+            </label>
+            <label className="block space-y-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+              <span>Filtrer par type</span>
+              <select
+                value={filters.typeFilter}
+                onChange={(event) =>
+                  setFilters((current) => ({
+                    ...current,
+                    typeFilter: event.target.value as Bookmark["type"] | "",
+                  }))
+                }
+                className={filterControlClassName}
+              >
+                <option value="">Tous les types</option>
+                {bookmarkTypes.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          {tags.length > 0 ? (
+            <fieldset className="mt-4 space-y-2">
+              <legend className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Filtrer par tags
+              </legend>
+              <div className="flex flex-wrap gap-2">
+                {tags.map(({ tag, count }) => (
+                  <label
+                    key={tag}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-2 text-sm text-slate-700 dark:border-slate-700 dark:text-slate-200"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={filters.selectedTags.includes(tag)}
+                      onChange={() => toggleTag(tag)}
+                      className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900 dark:border-slate-700 dark:bg-slate-950"
+                    />
+                    <span>
+                      {tag} ({count})
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          ) : null}
+          {hasActiveFilters ? (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="mt-4 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            >
+              Effacer les filtres
+            </button>
+          ) : null}
+        </section>
         <BookmarkGrid
-          bookmarks={visibleBookmarks}
+          bookmarks={filteredBookmarks}
           onSaveBookmark={onSaveBookmark}
           onDeleteBookmark={handleDeleteBookmark}
         />
       </div>
     </main>
   );
+}
+
+type BookmarkFilters = {
+  selectedTags: string[];
+  textFilter: string;
+  typeFilter: Bookmark["type"] | "";
+};
+
+function getInitialBookmarkFilters(): BookmarkFilters {
+  if (typeof window === "undefined") {
+    return { selectedTags: [], textFilter: "", typeFilter: "" };
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const typeFilter = parseBookmarkType(params.get("type"));
+
+  return {
+    selectedTags: parseTagsParam(params.get("tags")),
+    textFilter: params.get("q") ?? "",
+    typeFilter,
+  };
+}
+
+function syncBookmarkFiltersToUrl(filters: BookmarkFilters) {
+  if (typeof window === "undefined") return;
+
+  const params = new URLSearchParams(window.location.search);
+  const textFilter = filters.textFilter.trim();
+  if (textFilter) {
+    params.set("q", textFilter);
+  } else {
+    params.delete("q");
+  }
+
+  if (filters.typeFilter) {
+    params.set("type", filters.typeFilter);
+  } else {
+    params.delete("type");
+  }
+
+  if (filters.selectedTags.length > 0) {
+    params.set("tags", filters.selectedTags.join(","));
+  } else {
+    params.delete("tags");
+  }
+
+  const search = params.toString();
+  const nextUrl = `${window.location.pathname}${search ? `?${search}` : ""}${window.location.hash}`;
+  window.history.replaceState(window.history.state, "", nextUrl);
+}
+
+function parseBookmarkType(value: string | null): Bookmark["type"] | "" {
+  if (bookmarkTypes.some((type) => type === value)) return value as Bookmark["type"];
+
+  return "";
+}
+
+function parseTagsParam(value: string | null) {
+  if (!value) return [];
+
+  return value
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function filterBookmarks(bookmarks: Bookmark[], filters: BookmarkFilters) {
+  return filterBookmarksByText(bookmarks, filters.textFilter).filter((bookmark) => {
+    const matchesType = !filters.typeFilter || bookmark.type === filters.typeFilter;
+    const matchesTags =
+      filters.selectedTags.length === 0 ||
+      filters.selectedTags.some((tag) => bookmark.tags.includes(tag));
+
+    return matchesType && matchesTags;
+  });
+}
+
+function hasActiveBookmarkFilters(filters: BookmarkFilters) {
+  return Boolean(filters.textFilter || filters.typeFilter || filters.selectedTags.length > 0);
+}
+
+function filterBookmarksByText(bookmarks: Bookmark[], textFilter: string) {
+  const query = textFilter.trim().toLocaleLowerCase();
+  if (!query) return bookmarks;
+
+  return bookmarks.filter((bookmark) => {
+    return (
+      bookmark.title.toLocaleLowerCase().includes(query) ||
+      bookmark.url.toLocaleLowerCase().includes(query)
+    );
+  });
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,23 +1,24 @@
-import type { Bookmark } from "@stashbox/shared";
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 
 import { BookmarkBrowsePage } from "~/components/bookmarks/bookmark-browse-page.tsx";
-import { addBookmark, deleteBookmark, loadInitialBookmarks } from "~/server/stashbox.ts";
+import type { InitialBrowseData } from "~/server/stashbox.ts";
+import { addBookmark, deleteBookmark, loadInitialBrowseData } from "~/server/stashbox.ts";
 
 export const Route = createFileRoute("/")({
-  loader: () => loadInitialBookmarks(),
+  loader: () => loadInitialBrowseData(),
   errorComponent: HomeErrorPage,
   component: HomePage,
 });
 
 function HomePage() {
-  const bookmarks = Route.useLoaderData() as Bookmark[];
+  const { bookmarks, tags } = Route.useLoaderData() as InitialBrowseData;
   const saveBookmark = useSaveBookmark();
   const removeBookmark = useDeleteBookmark();
 
   return (
     <BookmarkBrowsePage
       bookmarks={bookmarks}
+      tags={tags}
       onSaveBookmark={saveBookmark}
       onDeleteBookmark={removeBookmark}
     />
@@ -31,6 +32,7 @@ function HomeErrorPage() {
   return (
     <BookmarkBrowsePage
       bookmarks={[]}
+      tags={[]}
       loadError="Impossible de charger les Bookmarks."
       onSaveBookmark={saveBookmark}
       onDeleteBookmark={removeBookmark}

--- a/apps/web/src/server/stashbox.ts
+++ b/apps/web/src/server/stashbox.ts
@@ -1,4 +1,4 @@
-import type { AddParams, ListParams, SearchParams } from "@stashbox/api-client";
+import type { AddParams, ListParams, SearchParams, Tag } from "@stashbox/api-client";
 import { StashboxClient } from "@stashbox/api-client";
 import type { Bookmark } from "@stashbox/shared";
 import { createServerFn, serverOnly } from "@tanstack/react-start";
@@ -107,9 +107,15 @@ export const listTags = createServerFn({ method: "GET" })
   .type("dynamic")
   .handler(async () => createStashboxServerOperations().listTags());
 
-export async function loadInitialBookmarks() {
-  return (
-    ((await listBookmarks({ data: initialBookmarksPage })) as Bookmark[] | undefined) ??
-    createStashboxServerOperations().listBookmarks(initialBookmarksPage)
-  );
+export type InitialBrowseData = {
+  bookmarks: Bookmark[];
+  tags: Tag[];
+};
+
+export async function loadInitialBrowseData(): Promise<InitialBrowseData> {
+  const operations = createStashboxServerOperations();
+  const bookmarks = await operations.listBookmarks(initialBookmarksPage);
+  const tags = await operations.listTags();
+
+  return { bookmarks, tags };
 }

--- a/apps/web/tests/bookmark-browse-page.test.tsx
+++ b/apps/web/tests/bookmark-browse-page.test.tsx
@@ -10,6 +10,7 @@ describe("BookmarkBrowsePage", () => {
   afterEach(() => {
     localStorage.clear();
     document.documentElement.classList.remove("dark");
+    window.history.replaceState(null, "", "/");
     vi.unstubAllGlobals();
   });
 
@@ -41,6 +42,200 @@ describe("BookmarkBrowsePage", () => {
     );
 
     expect(screen.getByText("2 Bookmarks")).toBeInTheDocument();
+  });
+
+  it("filters Bookmarks by title or URL text", () => {
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+            url: "https://example.com/readable-systems",
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000002",
+            title: "Vue patterns",
+            url: "https://docs.example.com/vue-patterns",
+          }),
+        ]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filtrer par texte"), {
+      target: { value: "docs.example" },
+    });
+
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Vue patterns" })).toBeInTheDocument();
+    expect(screen.getByText("1 Bookmark")).toBeInTheDocument();
+  });
+
+  it("filters Bookmarks by selected type", () => {
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+            type: "article",
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000002",
+            title: "Nuxt walkthrough",
+            type: "youtube",
+          }),
+        ]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filtrer par type"), {
+      target: { value: "youtube" },
+    });
+
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Nuxt walkthrough" })).toBeInTheDocument();
+    expect(screen.getByText("1 Bookmark")).toBeInTheDocument();
+  });
+
+  it("filters Bookmarks by selected Tags with OR semantics and combines other filters with AND", () => {
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+            type: "article",
+            tags: ["architecture"],
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000002",
+            title: "Nuxt patterns",
+            type: "youtube",
+            tags: ["vue"],
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000003",
+            title: "Nuxt architecture",
+            type: "youtube",
+            tags: ["architecture"],
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000004",
+            title: "Nuxt design",
+            type: "youtube",
+            tags: ["design"],
+          }),
+        ]}
+        tags={[
+          { tag: "architecture", count: 2 },
+          { tag: "vue", count: 1 },
+          { tag: "design", count: 1 },
+        ]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filtrer par texte"), {
+      target: { value: "nuxt" },
+    });
+    fireEvent.change(screen.getByLabelText("Filtrer par type"), {
+      target: { value: "youtube" },
+    });
+    fireEvent.click(screen.getByLabelText("architecture (2)"));
+    fireEvent.click(screen.getByLabelText("vue (1)"));
+
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Nuxt patterns" })).toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Nuxt architecture" })).toBeInTheDocument();
+    expect(screen.queryByRole("article", { name: "Nuxt design" })).not.toBeInTheDocument();
+    expect(screen.getByText("2 Bookmarks")).toBeInTheDocument();
+  });
+
+  it("syncs active filters to the URL and clears them from the grid", () => {
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+            type: "article",
+            tags: ["architecture"],
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000002",
+            title: "Nuxt architecture",
+            type: "youtube",
+            tags: ["architecture"],
+          }),
+        ]}
+        tags={[{ tag: "architecture", count: 2 }]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filtrer par texte"), {
+      target: { value: "nuxt" },
+    });
+    fireEvent.change(screen.getByLabelText("Filtrer par type"), {
+      target: { value: "youtube" },
+    });
+    fireEvent.click(screen.getByLabelText("architecture (2)"));
+
+    const activeParams = new URLSearchParams(window.location.search);
+    expect(activeParams.get("q")).toBe("nuxt");
+    expect(activeParams.get("type")).toBe("youtube");
+    expect(activeParams.get("tags")).toBe("architecture");
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Nuxt architecture" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Effacer les filtres" }));
+
+    expect(window.location.search).toBe("");
+    expect(screen.getByLabelText("Filtrer par texte")).toHaveValue("");
+    expect(screen.getByLabelText("Filtrer par type")).toHaveValue("");
+    expect(screen.getByLabelText("architecture (2)")).not.toBeChecked();
+    expect(screen.getByRole("article", { name: "Readable systems" })).toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Nuxt architecture" })).toBeInTheDocument();
+    expect(screen.getByText("2 Bookmarks")).toBeInTheDocument();
+  });
+
+  it("initializes active filters from the URL query string", () => {
+    window.history.replaceState(null, "", "/?q=nuxt&type=youtube&tags=architecture");
+
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+            type: "article",
+            tags: ["architecture"],
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000002",
+            title: "Nuxt architecture",
+            type: "youtube",
+            tags: ["architecture"],
+          }),
+        ]}
+        tags={[{ tag: "architecture", count: 2 }]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("Filtrer par texte")).toHaveValue("nuxt");
+    expect(screen.getByLabelText("Filtrer par type")).toHaveValue("youtube");
+    expect(screen.getByLabelText("architecture (2)")).toBeChecked();
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Nuxt architecture" })).toBeInTheDocument();
   });
 
   it("shows a load error without hiding the page shell", () => {

--- a/apps/web/tests/home-route.test.ts
+++ b/apps/web/tests/home-route.test.ts
@@ -1,3 +1,4 @@
+import type { Tag } from "@stashbox/api-client";
 import type { Bookmark } from "@stashbox/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -7,22 +8,30 @@ describe("home route", () => {
     vi.unstubAllGlobals();
   });
 
-  it("loads the first page of Bookmarks through the server function", async () => {
+  it("loads the first page of Bookmarks and Tags through the server functions", async () => {
     vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
     vi.stubEnv("STASHBOX_API_KEY", "secret-key");
     vi.resetModules();
 
     const bookmark = createBookmark({ title: "Readable systems" });
+    const tags: Tag[] = [{ tag: "architecture", count: 1 }];
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
       requests.push({ url: String(url), init });
+      if (String(url).endsWith("/tags")) return Response.json({ results: tags });
       return Response.json({ results: [bookmark] });
     });
 
     const { Route } = await import("~/routes/index.tsx");
 
-    await expect(Route.options.loader?.({} as never)).resolves.toEqual([bookmark]);
-    expect(requests[0]?.url).toBe("https://stashbox.example/bookmarks?limit=48&offset=0");
+    await expect(Route.options.loader?.({} as never)).resolves.toEqual({
+      bookmarks: [bookmark],
+      tags,
+    });
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://stashbox.example/bookmarks?limit=48&offset=0",
+      "https://stashbox.example/tags",
+    ]);
   });
 });
 

--- a/apps/web/tests/setup.ts
+++ b/apps/web/tests/setup.ts
@@ -1,1 +1,32 @@
 import "@testing-library/jest-dom/vitest";
+
+if (
+  typeof globalThis.localStorage === "undefined" ||
+  typeof globalThis.localStorage.clear !== "function"
+) {
+  const storage = new Map<string, string>();
+
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      get length() {
+        return storage.size;
+      },
+      clear() {
+        storage.clear();
+      },
+      getItem(key: string) {
+        return storage.get(key) ?? null;
+      },
+      key(index: number) {
+        return Array.from(storage.keys())[index] ?? null;
+      },
+      removeItem(key: string) {
+        storage.delete(key);
+      },
+      setItem(key: string, value: string) {
+        storage.set(key, value);
+      },
+    },
+  });
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,7 +14,7 @@
 - [x] GREEN: wire filter state to query string.
 - [x] Refactor only after green.
 - [x] Verify with web tests, typecheck, targeted lint, and formatting.
-- [ ] Push branch and create draft PR linked with `Closes #39`.
+- [x] Push branch and create draft PR linked with `Closes #39`.
 
 ## Scope
 
@@ -31,3 +31,4 @@
 - Full `pnpm --filter @stashbox/web lint` is blocked by pre-existing generated
   `apps/web/app.config.timestamp_*.js` import-sort errors and unrelated import
   order errors outside this change.
+- Draft PR: https://github.com/Nardjo/stashbox/pull/49

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,27 +1,33 @@
-# Issue #38 - Delete Bookmark
+# Issue #39 - Bookmark Filter Bar
 
 ## Plan
 
-- [x] RED: prove cancelling the delete confirmation keeps the bookmark and does not call delete.
-- [x] GREEN: add a delete button and confirmation dialog with cancel behavior.
-- [x] RED: prove confirming delete calls the delete action and removes the card without page reload.
-- [x] GREEN: wire `deleteBookmark` through the browse page and update local grid state.
-- [x] RED: prove the delete button is disabled while deletion is in flight.
-- [x] GREEN: add in-flight state and accessible disabled UI.
+- [x] RED: prove the home loader fetches Tags with Bookmarks.
+- [x] GREEN: expose Tags to the browse page.
+- [x] RED: prove text filtering narrows Bookmarks by title or URL.
+- [x] GREEN: add filter bar text input and client-side filtering.
+- [x] RED: prove type filtering narrows Bookmarks by selected Type.
+- [x] GREEN: add Type select.
+- [x] RED: prove selected Tags filter with OR semantics and combine with text/type by AND.
+- [x] GREEN: add Tag multi-select.
+- [x] RED: prove clearing filters restores the full grid and URL query reflects active filters.
+- [x] GREEN: wire filter state to query string.
 - [x] Refactor only after green.
-- [x] Verify with web tests, typecheck, and targeted lint.
-- [ ] Push branch and create draft PR linked with `Closes #38`.
+- [x] Verify with web tests, typecheck, targeted lint, and formatting.
+- [ ] Push branch and create draft PR linked with `Closes #39`.
 
 ## Scope
 
 - App: `apps/web`.
-- Public interface: user interacts with `BookmarkBrowsePage` / `BookmarkCard`.
+- Public interface: Owner filters Bookmarks from the main browse page.
 - User-facing copy: French.
 
 ## Review
 
-- `pnpm --filter @stashbox/web test` passed: 9 files, 40 tests.
+- `pnpm --filter @stashbox/web test` passed: 45 tests.
 - `pnpm --filter @stashbox/web typecheck` passed.
-- Targeted ESLint passed on changed web files.
-- Prettier check passed on changed files.
-- Full `pnpm --filter @stashbox/web lint` is blocked by existing generated `app.config.timestamp_*.js` import-sort errors outside this change.
+- Targeted ESLint passed on modified web files.
+- `pnpm --filter @stashbox/web build` passed.
+- Full `pnpm --filter @stashbox/web lint` is blocked by pre-existing generated
+  `apps/web/app.config.timestamp_*.js` import-sort errors and unrelated import
+  order errors outside this change.


### PR DESCRIPTION
Closes #39

## Summary

- Fetch tag vocabulary with the initial Bookmark page.
- Add text, type, and tag filters above the Bookmark grid.
- Sync active filters with the URL query string and add clear filters.

## Test plan

- [x] pnpm --filter @stashbox/web test
- [x] pnpm --filter @stashbox/web typecheck
- [x] pnpm --filter @stashbox/web build
- [x] targeted ESLint on modified web files

Note: full web lint is blocked by pre-existing generated app.config.timestamp_*.js import-sort errors and unrelated import-sort errors outside this change.