### PR TITLE
feat: pagination de la grille de bookmarks

### DIFF
--- a/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
@@ -12,23 +12,31 @@ const filterControlClassName =
   "w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none transition focus:border-slate-900 focus:ring-2 focus:ring-slate-900/10 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-slate-200 dark:focus:ring-slate-200/10";
 
 type BookmarkBrowsePageProps = {
+  bookmarkPageSize?: number;
   bookmarks: Bookmark[];
+  hasMoreBookmarks?: boolean;
   tags?: Tag[];
   loadError?: string;
   onSaveBookmark: (url: string) => Promise<void>;
   onDeleteBookmark: (id: string) => Promise<void>;
+  onLoadMoreBookmarks?: (params: BookmarkPageParams) => Promise<Bookmark[]>;
 };
 
 export function BookmarkBrowsePage({
+  bookmarkPageSize = 48,
   bookmarks,
+  hasMoreBookmarks = false,
   tags = [],
   loadError,
   onSaveBookmark,
   onDeleteBookmark,
+  onLoadMoreBookmarks,
 }: BookmarkBrowsePageProps) {
   const [visibleBookmarks, setVisibleBookmarks] = useState(bookmarks);
   const [filters, setFilters] = useState<BookmarkFilters>(emptyBookmarkFilters);
   const [hasLoadedUrlFilters, setHasLoadedUrlFilters] = useState(false);
+  const [canLoadMoreBookmarks, setCanLoadMoreBookmarks] = useState(hasMoreBookmarks);
+  const [isLoadingMoreBookmarks, setIsLoadingMoreBookmarks] = useState(false);
   const filteredBookmarks = filterBookmarks(visibleBookmarks, filters);
   const countLabel =
     filteredBookmarks.length === 1 ? "1 Bookmark" : `${filteredBookmarks.length} Bookmarks`;
@@ -36,7 +44,8 @@ export function BookmarkBrowsePage({
 
   useEffect(() => {
     setVisibleBookmarks(bookmarks);
-  }, [bookmarks]);
+    setCanLoadMoreBookmarks(hasMoreBookmarks);
+  }, [bookmarks, filters, hasMoreBookmarks]);
 
   useEffect(() => {
     setFilters(getInitialBookmarkFilters());
@@ -52,6 +61,22 @@ export function BookmarkBrowsePage({
   async function handleDeleteBookmark(id: string) {
     await onDeleteBookmark(id);
     setVisibleBookmarks((current) => current.filter((bookmark) => bookmark.id !== id));
+  }
+
+  async function handleLoadMoreBookmarks() {
+    if (!onLoadMoreBookmarks || isLoadingMoreBookmarks) return;
+
+    setIsLoadingMoreBookmarks(true);
+    try {
+      const nextBookmarks = await onLoadMoreBookmarks({
+        limit: bookmarkPageSize,
+        offset: visibleBookmarks.length,
+      });
+      setVisibleBookmarks((current) => [...current, ...nextBookmarks]);
+      setCanLoadMoreBookmarks(nextBookmarks.length === bookmarkPageSize);
+    } finally {
+      setIsLoadingMoreBookmarks(false);
+    }
   }
 
   function toggleTag(tag: string) {
@@ -177,10 +202,27 @@ export function BookmarkBrowsePage({
           onSaveBookmark={onSaveBookmark}
           onDeleteBookmark={handleDeleteBookmark}
         />
+        {onLoadMoreBookmarks && canLoadMoreBookmarks ? (
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={handleLoadMoreBookmarks}
+              disabled={isLoadingMoreBookmarks}
+              className="rounded-full bg-slate-900 px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-100 dark:text-slate-950 dark:hover:bg-slate-300"
+            >
+              {isLoadingMoreBookmarks ? "Chargement..." : "Charger plus"}
+            </button>
+          </div>
+        ) : null}
       </div>
     </main>
   );
 }
+
+type BookmarkPageParams = {
+  limit: number;
+  offset: number;
+};
 
 type BookmarkFilters = {
   selectedTags: string[];

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,8 +1,14 @@
+import type { Bookmark } from "@stashbox/shared";
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 
 import { BookmarkBrowsePage } from "~/components/bookmarks/bookmark-browse-page.tsx";
 import type { InitialBrowseData } from "~/server/stashbox.ts";
-import { addBookmark, deleteBookmark, loadInitialBrowseData } from "~/server/stashbox.ts";
+import {
+  addBookmark,
+  deleteBookmark,
+  listBookmarks,
+  loadInitialBrowseData,
+} from "~/server/stashbox.ts";
 
 export const Route = createFileRoute("/")({
   loader: () => loadInitialBrowseData(),
@@ -11,16 +17,21 @@ export const Route = createFileRoute("/")({
 });
 
 function HomePage() {
-  const { bookmarks, tags } = Route.useLoaderData() as InitialBrowseData;
+  const { bookmarkPageSize, bookmarks, hasMoreBookmarks, tags } =
+    Route.useLoaderData() as InitialBrowseData;
   const saveBookmark = useSaveBookmark();
   const removeBookmark = useDeleteBookmark();
+  const loadMoreBookmarks = useLoadMoreBookmarks();
 
   return (
     <BookmarkBrowsePage
+      bookmarkPageSize={bookmarkPageSize}
       bookmarks={bookmarks}
+      hasMoreBookmarks={hasMoreBookmarks}
       tags={tags}
       onSaveBookmark={saveBookmark}
       onDeleteBookmark={removeBookmark}
+      onLoadMoreBookmarks={loadMoreBookmarks}
     />
   );
 }
@@ -52,5 +63,11 @@ function useSaveBookmark() {
 function useDeleteBookmark() {
   return async (id: string) => {
     await deleteBookmark({ data: { id } });
+  };
+}
+
+function useLoadMoreBookmarks() {
+  return async (params: { limit: number; offset: number }) => {
+    return ((await listBookmarks({ data: params })) as Bookmark[] | undefined) ?? [];
   };
 }

--- a/apps/web/src/server/stashbox.ts
+++ b/apps/web/src/server/stashbox.ts
@@ -108,7 +108,9 @@ export const listTags = createServerFn({ method: "GET" })
   .handler(async () => createStashboxServerOperations().listTags());
 
 export type InitialBrowseData = {
+  bookmarkPageSize: number;
   bookmarks: Bookmark[];
+  hasMoreBookmarks: boolean;
   tags: Tag[];
 };
 
@@ -117,5 +119,10 @@ export async function loadInitialBrowseData(): Promise<InitialBrowseData> {
   const bookmarks = await operations.listBookmarks(initialBookmarksPage);
   const tags = await operations.listTags();
 
-  return { bookmarks, tags };
+  return {
+    bookmarkPageSize: initialBookmarksPage.limit,
+    bookmarks,
+    hasMoreBookmarks: bookmarks.length === initialBookmarksPage.limit,
+    tags,
+  };
 }

--- a/apps/web/tests/bookmark-browse-page.test.tsx
+++ b/apps/web/tests/bookmark-browse-page.test.tsx
@@ -44,6 +44,155 @@ describe("BookmarkBrowsePage", () => {
     expect(screen.getByText("2 Bookmarks")).toBeInTheDocument();
   });
 
+  it("loads the next Bookmark page and appends it to the grid", async () => {
+    const loadMoreBookmarks = vi.fn().mockResolvedValue([
+      createBookmark({
+        id: "00000000-0000-4000-8000-000000000003",
+        title: "Pagination systems",
+      }),
+    ]);
+
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000002",
+            title: "Vue patterns",
+          }),
+        ]}
+        bookmarkPageSize={2}
+        hasMoreBookmarks={true}
+        onLoadMoreBookmarks={loadMoreBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Charger plus" }));
+
+    await waitFor(() => expect(loadMoreBookmarks).toHaveBeenCalledWith({ limit: 2, offset: 2 }));
+    expect(screen.getByRole("article", { name: "Pagination systems" })).toBeInTheDocument();
+    expect(screen.getByText("3 Bookmarks")).toBeInTheDocument();
+  });
+
+  it("hides the load more trigger after a short page is loaded", async () => {
+    const loadMoreBookmarks = vi.fn().mockResolvedValue([
+      createBookmark({
+        id: "00000000-0000-4000-8000-000000000003",
+        title: "Last Bookmark",
+      }),
+    ]);
+
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000002",
+            title: "Vue patterns",
+          }),
+        ]}
+        bookmarkPageSize={2}
+        hasMoreBookmarks={true}
+        onLoadMoreBookmarks={loadMoreBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Charger plus" }));
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Charger plus" })).toBeNull());
+    expect(screen.getByRole("article", { name: "Last Bookmark" })).toBeInTheDocument();
+  });
+
+  it("shows a loading state while the next Bookmark page is loading", async () => {
+    let finishLoad!: (bookmarks: Bookmark[]) => void;
+    const loadMoreBookmarks = vi.fn(
+      () =>
+        new Promise<Bookmark[]>((resolve) => {
+          finishLoad = resolve;
+        }),
+    );
+
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000002",
+            title: "Vue patterns",
+          }),
+        ]}
+        bookmarkPageSize={2}
+        hasMoreBookmarks={true}
+        onLoadMoreBookmarks={loadMoreBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Charger plus" }));
+
+    const loadingButton = await screen.findByRole("button", { name: "Chargement..." });
+    expect(loadingButton).toBeDisabled();
+
+    finishLoad([]);
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Chargement..." })).not.toBeInTheDocument(),
+    );
+  });
+
+  it("resets loaded pages when active filters change", async () => {
+    const loadMoreBookmarks = vi.fn().mockResolvedValue([
+      createBookmark({
+        id: "00000000-0000-4000-8000-000000000003",
+        title: "Pagination systems",
+      }),
+    ]);
+
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+          }),
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000002",
+            title: "Vue patterns",
+          }),
+        ]}
+        bookmarkPageSize={2}
+        hasMoreBookmarks={true}
+        onLoadMoreBookmarks={loadMoreBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Charger plus" }));
+    expect(await screen.findByRole("article", { name: "Pagination systems" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filtrer par texte"), {
+      target: { value: "pagination" },
+    });
+
+    expect(screen.queryByRole("article", { name: "Pagination systems" })).not.toBeInTheDocument();
+    expect(screen.getByText("0 Bookmarks")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Charger plus" })).toBeInTheDocument();
+  });
+
   it("filters Bookmarks by title or URL text", () => {
     renderPage(
       <BookmarkBrowsePage

--- a/apps/web/tests/home-route.test.ts
+++ b/apps/web/tests/home-route.test.ts
@@ -13,19 +13,26 @@ describe("home route", () => {
     vi.stubEnv("STASHBOX_API_KEY", "secret-key");
     vi.resetModules();
 
-    const bookmark = createBookmark({ title: "Readable systems" });
+    const bookmarks = Array.from({ length: 48 }, (_, index) =>
+      createBookmark({
+        id: `00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+        title: `Readable systems ${index + 1}`,
+      }),
+    );
     const tags: Tag[] = [{ tag: "architecture", count: 1 }];
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
       requests.push({ url: String(url), init });
       if (String(url).endsWith("/tags")) return Response.json({ results: tags });
-      return Response.json({ results: [bookmark] });
+      return Response.json({ results: bookmarks });
     });
 
     const { Route } = await import("~/routes/index.tsx");
 
     await expect(Route.options.loader?.({} as never)).resolves.toEqual({
-      bookmarks: [bookmark],
+      bookmarkPageSize: 48,
+      bookmarks,
+      hasMoreBookmarks: true,
       tags,
     });
     expect(requests.map((request) => request.url)).toEqual([

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,34 +1,32 @@
-# Issue #39 - Bookmark Filter Bar
+# Issue #41 - Bookmark Grid Pagination
 
 ## Plan
 
-- [x] RED: prove the home loader fetches Tags with Bookmarks.
-- [x] GREEN: expose Tags to the browse page.
-- [x] RED: prove text filtering narrows Bookmarks by title or URL.
-- [x] GREEN: add filter bar text input and client-side filtering.
-- [x] RED: prove type filtering narrows Bookmarks by selected Type.
-- [x] GREEN: add Type select.
-- [x] RED: prove selected Tags filter with OR semantics and combine with text/type by AND.
-- [x] GREEN: add Tag multi-select.
-- [x] RED: prove clearing filters restores the full grid and URL query reflects active filters.
-- [x] GREEN: wire filter state to query string.
+- [x] RED: prove initial browse data exposes page size and `hasMoreBookmarks`.
+- [x] GREEN: return pagination metadata from the home loader.
+- [x] RED: prove "Charger plus" fetches the next page with `offset: 48` and appends cards.
+- [x] GREEN: add load-more callback, loading state, and append behavior.
+- [x] RED: prove load trigger is hidden when the returned page is shorter than the limit.
+- [x] GREEN: compute `hasMoreBookmarks` after each page.
+- [x] RED: prove pagination state resets when filters change.
+- [x] GREEN: reset loaded pages to the initial page on filter changes.
 - [x] Refactor only after green.
-- [x] Verify with web tests, typecheck, targeted lint, and formatting.
-- [x] Push branch and create draft PR linked with `Closes #39`.
+- [x] Verify with web tests, typecheck, targeted lint, and build.
+- [ ] Push branch and create draft PR linked with `Closes #41`.
 
 ## Scope
 
 - App: `apps/web`.
-- Public interface: Owner filters Bookmarks from the main browse page.
+- Public interface: Owner loads more Bookmarks from the main browse grid.
+- Trigger: explicit "Charger plus" button.
 - User-facing copy: French.
 
 ## Review
 
-- `pnpm --filter @stashbox/web test` passed: 45 tests.
+- `pnpm --filter @stashbox/web test` passed: 49 tests.
 - `pnpm --filter @stashbox/web typecheck` passed.
 - Targeted ESLint passed on modified web files.
 - `pnpm --filter @stashbox/web build` passed.
 - Full `pnpm --filter @stashbox/web lint` is blocked by pre-existing generated
   `apps/web/app.config.timestamp_*.js` import-sort errors and unrelated import
   order errors outside this change.
-- Draft PR: https://github.com/Nardjo/stashbox/pull/49

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12,7 +12,7 @@
 - [x] GREEN: reset loaded pages to the initial page on filter changes.
 - [x] Refactor only after green.
 - [x] Verify with web tests, typecheck, targeted lint, and build.
-- [ ] Push branch and create draft PR linked with `Closes #41`.
+- [x] Push branch and create draft PR linked with `Closes #41`.
 
 ## Scope
 
@@ -30,3 +30,4 @@
 - Full `pnpm --filter @stashbox/web lint` is blocked by pre-existing generated
   `apps/web/app.config.timestamp_*.js` import-sort errors and unrelated import
   order errors outside this change.
+- Draft PR: https://github.com/Nardjo/stashbox/pull/50


### PR DESCRIPTION
Closes #41

## Summary

- Add pagination metadata to the initial browse loader.
- Add a "Charger plus" flow that fetches the next Bookmark page and appends results.
- Hide the load trigger after a short page and reset loaded pages when filters change.

## Test plan

- [x] pnpm --filter @stashbox/web test
- [x] pnpm --filter @stashbox/web typecheck
- [x] pnpm --filter @stashbox/web build
- [x] targeted ESLint on modified web files

Note: full web lint is blocked by pre-existing generated app.config.timestamp_*.js import-sort errors and unrelated import-sort errors outside this change.