### PR TITLE
feat: recherche semantique web

### DIFF
--- a/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
@@ -1,5 +1,6 @@
 import type { Tag } from "@stashbox/api-client";
 import type { Bookmark } from "@stashbox/shared";
+import type { FormEvent } from "react";
 import { useEffect, useState } from "react";
 
 import { ThemeToggle } from "~/components/theme/theme.tsx";
@@ -7,6 +8,7 @@ import { ThemeToggle } from "~/components/theme/theme.tsx";
 import { BookmarkGrid } from "./bookmark-grid.tsx";
 
 const bookmarkTypes = ["tweet", "youtube", "article", "image", "pdf", "other"] as const;
+const semanticSearchParamName = "semantic";
 const emptyBookmarkFilters: BookmarkFilters = { selectedTags: [], textFilter: "", typeFilter: "" };
 const filterControlClassName =
   "w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none transition focus:border-slate-900 focus:ring-2 focus:ring-slate-900/10 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-slate-200 dark:focus:ring-slate-200/10";
@@ -20,6 +22,7 @@ type BookmarkBrowsePageProps = {
   onSaveBookmark: (url: string) => Promise<void>;
   onDeleteBookmark: (id: string) => Promise<void>;
   onLoadMoreBookmarks?: (params: BookmarkPageParams) => Promise<Bookmark[]>;
+  onSearchBookmarks?: (query: string) => Promise<Bookmark[]>;
 };
 
 export function BookmarkBrowsePage({
@@ -31,15 +34,27 @@ export function BookmarkBrowsePage({
   onSaveBookmark,
   onDeleteBookmark,
   onLoadMoreBookmarks,
+  onSearchBookmarks,
 }: BookmarkBrowsePageProps) {
   const [visibleBookmarks, setVisibleBookmarks] = useState(bookmarks);
   const [filters, setFilters] = useState<BookmarkFilters>(emptyBookmarkFilters);
+  const [semanticQuery, setSemanticQuery] = useState(getInitialSemanticSearchQuery);
+  const [semanticResults, setSemanticResults] = useState<Bookmark[] | null>(null);
+  const [isSearchingBookmarks, setIsSearchingBookmarks] = useState(false);
   const [hasLoadedUrlFilters, setHasLoadedUrlFilters] = useState(false);
+  const [hasRestoredUrlSemanticSearch, setHasRestoredUrlSemanticSearch] = useState(false);
   const [canLoadMoreBookmarks, setCanLoadMoreBookmarks] = useState(hasMoreBookmarks);
   const [isLoadingMoreBookmarks, setIsLoadingMoreBookmarks] = useState(false);
   const filteredBookmarks = filterBookmarks(visibleBookmarks, filters);
-  const countLabel =
-    filteredBookmarks.length === 1 ? "1 Bookmark" : `${filteredBookmarks.length} Bookmarks`;
+  const isSemanticSearchActive = semanticResults !== null;
+  const displayedBookmarks = semanticResults ?? filteredBookmarks;
+  const hasEmptySemanticResults =
+    isSemanticSearchActive && !isSearchingBookmarks && displayedBookmarks.length === 0;
+  const countLabel = isSemanticSearchActive
+    ? formatSemanticResultCount(displayedBookmarks.length)
+    : filteredBookmarks.length === 1
+      ? "1 Bookmark"
+      : `${filteredBookmarks.length} Bookmarks`;
   const hasActiveFilters = hasActiveBookmarkFilters(filters);
 
   useEffect(() => {
@@ -57,6 +72,19 @@ export function BookmarkBrowsePage({
 
     syncBookmarkFiltersToUrl(filters);
   }, [filters, hasLoadedUrlFilters]);
+
+  useEffect(() => {
+    if (hasRestoredUrlSemanticSearch) return;
+
+    setHasRestoredUrlSemanticSearch(true);
+    const query = semanticQuery.trim();
+    if (!query || !onSearchBookmarks) return;
+
+    setIsSearchingBookmarks(true);
+    void onSearchBookmarks(query)
+      .then((results) => setSemanticResults(results))
+      .finally(() => setIsSearchingBookmarks(false));
+  }, [hasRestoredUrlSemanticSearch, onSearchBookmarks, semanticQuery]);
 
   async function handleDeleteBookmark(id: string) {
     await onDeleteBookmark(id);
@@ -79,6 +107,22 @@ export function BookmarkBrowsePage({
     }
   }
 
+  async function handleSemanticSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const query = semanticQuery.trim();
+    if (!query || !onSearchBookmarks || isSearchingBookmarks) return;
+
+    syncSemanticSearchToUrl(query);
+    setIsSearchingBookmarks(true);
+    try {
+      const results = await onSearchBookmarks(query);
+      setSemanticResults(results);
+    } finally {
+      setIsSearchingBookmarks(false);
+    }
+  }
+
   function toggleTag(tag: string) {
     setFilters((current) => {
       if (current.selectedTags.includes(tag)) {
@@ -94,6 +138,12 @@ export function BookmarkBrowsePage({
 
   function clearFilters() {
     setFilters(emptyBookmarkFilters);
+  }
+
+  function clearSemanticSearch() {
+    setSemanticQuery("");
+    setSemanticResults(null);
+    syncSemanticSearchToUrl("");
   }
 
   return (
@@ -124,6 +174,46 @@ export function BookmarkBrowsePage({
             </p>
           ) : null}
         </header>
+        <form
+          role="search"
+          aria-label="Recherche sémantique"
+          onSubmit={handleSemanticSearch}
+          className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+        >
+          <label
+            htmlFor="semantic-search-query"
+            className="block text-sm font-medium text-slate-700 dark:text-slate-200"
+          >
+            Rechercher par sens
+          </label>
+          <div className="mt-2 flex flex-col gap-3 sm:flex-row">
+            <input
+              id="semantic-search-query"
+              type="search"
+              value={semanticQuery}
+              onChange={(event) => setSemanticQuery(event.target.value)}
+              disabled={isSearchingBookmarks}
+              placeholder="Ex: articles sur l'architecture produit"
+              className={filterControlClassName}
+            />
+            <button
+              type="submit"
+              disabled={isSearchingBookmarks}
+              className="rounded-full bg-slate-900 px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-100 dark:text-slate-950 dark:hover:bg-slate-300"
+            >
+              {isSearchingBookmarks ? "Recherche..." : "Rechercher"}
+            </button>
+            {isSemanticSearchActive ? (
+              <button
+                type="button"
+                onClick={clearSemanticSearch}
+                className="rounded-full border border-slate-200 px-5 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              >
+                Effacer la recherche sémantique
+              </button>
+            ) : null}
+          </div>
+        </form>
         <section
           aria-label="Filtres de Bookmarks"
           className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900"
@@ -197,12 +287,19 @@ export function BookmarkBrowsePage({
             </button>
           ) : null}
         </section>
-        <BookmarkGrid
-          bookmarks={filteredBookmarks}
-          onSaveBookmark={onSaveBookmark}
-          onDeleteBookmark={handleDeleteBookmark}
-        />
-        {onLoadMoreBookmarks && canLoadMoreBookmarks ? (
+        {hasEmptySemanticResults ? (
+          <p className="rounded-2xl border border-slate-200 bg-white p-6 text-center text-sm text-slate-600 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+            Aucun résultat sémantique.
+          </p>
+        ) : (
+          <BookmarkGrid
+            bookmarks={displayedBookmarks}
+            onSaveBookmark={onSaveBookmark}
+            onDeleteBookmark={handleDeleteBookmark}
+            showAddBookmarkCard={!isSemanticSearchActive}
+          />
+        )}
+        {onLoadMoreBookmarks && canLoadMoreBookmarks && !isSemanticSearchActive ? (
           <div className="flex justify-center">
             <button
               type="button"
@@ -245,6 +342,12 @@ function getInitialBookmarkFilters(): BookmarkFilters {
   };
 }
 
+function getInitialSemanticSearchQuery() {
+  if (typeof window === "undefined") return "";
+
+  return new URLSearchParams(window.location.search).get(semanticSearchParamName) ?? "";
+}
+
 function syncBookmarkFiltersToUrl(filters: BookmarkFilters) {
   if (typeof window === "undefined") return;
 
@@ -266,6 +369,22 @@ function syncBookmarkFiltersToUrl(filters: BookmarkFilters) {
     params.set("tags", filters.selectedTags.join(","));
   } else {
     params.delete("tags");
+  }
+
+  const search = params.toString();
+  const nextUrl = `${window.location.pathname}${search ? `?${search}` : ""}${window.location.hash}`;
+  window.history.replaceState(window.history.state, "", nextUrl);
+}
+
+function syncSemanticSearchToUrl(query: string) {
+  if (typeof window === "undefined") return;
+
+  const params = new URLSearchParams(window.location.search);
+  const trimmedQuery = query.trim();
+  if (trimmedQuery) {
+    params.set(semanticSearchParamName, trimmedQuery);
+  } else {
+    params.delete(semanticSearchParamName);
   }
 
   const search = params.toString();
@@ -301,6 +420,10 @@ function filterBookmarks(bookmarks: Bookmark[], filters: BookmarkFilters) {
 
 function hasActiveBookmarkFilters(filters: BookmarkFilters) {
   return Boolean(filters.textFilter || filters.typeFilter || filters.selectedTags.length > 0);
+}
+
+function formatSemanticResultCount(count: number) {
+  return count === 1 ? "1 résultat sémantique" : `${count} résultats sémantiques`;
 }
 
 function filterBookmarksByText(bookmarks: Bookmark[], textFilter: string) {

--- a/apps/web/src/components/bookmarks/bookmark-grid.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-grid.tsx
@@ -7,18 +7,26 @@ type BookmarkGridProps = {
   bookmarks: Bookmark[];
   onSaveBookmark: (url: string) => Promise<void>;
   onDeleteBookmark: (id: string) => Promise<void>;
+  showAddBookmarkCard?: boolean;
 };
 
-export function BookmarkGrid({ bookmarks, onSaveBookmark, onDeleteBookmark }: BookmarkGridProps) {
+export function BookmarkGrid({
+  bookmarks,
+  onSaveBookmark,
+  onDeleteBookmark,
+  showAddBookmarkCard = true,
+}: BookmarkGridProps) {
   return (
     <div
       role="list"
       aria-label="Bookmarks"
       className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
     >
-      <div role="listitem">
-        <AddBookmarkCard onSaveBookmark={onSaveBookmark} />
-      </div>
+      {showAddBookmarkCard ? (
+        <div role="listitem">
+          <AddBookmarkCard onSaveBookmark={onSaveBookmark} />
+        </div>
+      ) : null}
       {bookmarks.map((bookmark) => (
         <div key={bookmark.id} role="listitem">
           <BookmarkCard bookmark={bookmark} onDeleteBookmark={onDeleteBookmark} />

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -8,6 +8,7 @@ import {
   deleteBookmark,
   listBookmarks,
   loadInitialBrowseData,
+  searchBookmarks,
 } from "~/server/stashbox.ts";
 
 export const Route = createFileRoute("/")({
@@ -22,6 +23,7 @@ function HomePage() {
   const saveBookmark = useSaveBookmark();
   const removeBookmark = useDeleteBookmark();
   const loadMoreBookmarks = useLoadMoreBookmarks();
+  const semanticSearchBookmarks = useSearchBookmarks();
 
   return (
     <BookmarkBrowsePage
@@ -32,6 +34,7 @@ function HomePage() {
       onSaveBookmark={saveBookmark}
       onDeleteBookmark={removeBookmark}
       onLoadMoreBookmarks={loadMoreBookmarks}
+      onSearchBookmarks={semanticSearchBookmarks}
     />
   );
 }
@@ -39,6 +42,7 @@ function HomePage() {
 function HomeErrorPage() {
   const saveBookmark = useSaveBookmark();
   const removeBookmark = useDeleteBookmark();
+  const semanticSearchBookmarks = useSearchBookmarks();
 
   return (
     <BookmarkBrowsePage
@@ -47,6 +51,7 @@ function HomeErrorPage() {
       loadError="Impossible de charger les Bookmarks."
       onSaveBookmark={saveBookmark}
       onDeleteBookmark={removeBookmark}
+      onSearchBookmarks={semanticSearchBookmarks}
     />
   );
 }
@@ -69,5 +74,13 @@ function useDeleteBookmark() {
 function useLoadMoreBookmarks() {
   return async (params: { limit: number; offset: number }) => {
     return ((await listBookmarks({ data: params })) as Bookmark[] | undefined) ?? [];
+  };
+}
+
+function useSearchBookmarks() {
+  return async (query: string) => {
+    return (
+      ((await searchBookmarks({ data: { query, limit: 48 } })) as Bookmark[] | undefined) ?? []
+    );
   };
 }

--- a/apps/web/tests/bookmark-browse-page.test.tsx
+++ b/apps/web/tests/bookmark-browse-page.test.tsx
@@ -44,6 +44,196 @@ describe("BookmarkBrowsePage", () => {
     expect(screen.getByText("2 Bookmarks")).toBeInTheDocument();
   });
 
+  it("shows a distinct semantic search input", () => {
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    expect(screen.getByRole("search", { name: "Recherche sémantique" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Rechercher par sens")).toBeInTheDocument();
+    expect(screen.getByLabelText("Filtrer par texte")).toBeInTheDocument();
+  });
+
+  it("submits a semantic query and replaces the browse grid with semantic results", async () => {
+    const searchBookmarks = vi.fn().mockResolvedValue([
+      createBookmark({
+        id: "00000000-0000-4000-8000-000000000003",
+        title: "Semantic architecture",
+      }),
+    ]);
+
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+          }),
+        ]}
+        onSearchBookmarks={searchBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Rechercher par sens"), {
+      target: { value: "architecture produit" },
+    });
+    fireEvent.submit(screen.getByRole("search", { name: "Recherche sémantique" }));
+
+    await waitFor(() => expect(searchBookmarks).toHaveBeenCalledWith("architecture produit"));
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Semantic architecture" })).toBeInTheDocument();
+    expect(screen.getByText("1 résultat sémantique")).toBeInTheDocument();
+  });
+
+  it("shows a loading state while semantic search is in flight", async () => {
+    let finishSearch!: (bookmarks: Bookmark[]) => void;
+    const searchBookmarks = vi.fn(
+      () =>
+        new Promise<Bookmark[]>((resolve) => {
+          finishSearch = resolve;
+        }),
+    );
+
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSearchBookmarks={searchBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Rechercher par sens"), {
+      target: { value: "architecture produit" },
+    });
+    fireEvent.submit(screen.getByRole("search", { name: "Recherche sémantique" }));
+
+    const loadingButton = await screen.findByRole("button", { name: "Recherche..." });
+    expect(loadingButton).toBeDisabled();
+
+    finishSearch([]);
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Recherche..." })).not.toBeInTheDocument(),
+    );
+  });
+
+  it("shows an empty state when semantic search returns no result", async () => {
+    const searchBookmarks = vi.fn().mockResolvedValue([]);
+
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSearchBookmarks={searchBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Rechercher par sens"), {
+      target: { value: "architecture produit" },
+    });
+    fireEvent.submit(screen.getByRole("search", { name: "Recherche sémantique" }));
+
+    expect(await screen.findByText("Aucun résultat sémantique.")).toBeInTheDocument();
+    expect(screen.getByText("0 résultats sémantiques")).toBeInTheDocument();
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+  });
+
+  it("clears semantic search and restores the browse grid", async () => {
+    const searchBookmarks = vi.fn().mockResolvedValue([
+      createBookmark({
+        id: "00000000-0000-4000-8000-000000000003",
+        title: "Semantic architecture",
+      }),
+    ]);
+
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[
+          createBookmark({
+            id: "00000000-0000-4000-8000-000000000001",
+            title: "Readable systems",
+          }),
+        ]}
+        onSearchBookmarks={searchBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Rechercher par sens"), {
+      target: { value: "architecture produit" },
+    });
+    fireEvent.submit(screen.getByRole("search", { name: "Recherche sémantique" }));
+    expect(
+      await screen.findByRole("article", { name: "Semantic architecture" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Effacer la recherche sémantique" }));
+
+    expect(
+      screen.queryByRole("article", { name: "Semantic architecture" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Readable systems" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Rechercher par sens")).toHaveValue("");
+    expect(screen.getByText("1 Bookmark")).toBeInTheDocument();
+  });
+
+  it("syncs semantic search to the URL and restores it on load", async () => {
+    const searchBookmarks = vi.fn().mockResolvedValue([
+      createBookmark({
+        id: "00000000-0000-4000-8000-000000000003",
+        title: "Semantic architecture",
+      }),
+    ]);
+
+    const { unmount } = renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSearchBookmarks={searchBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Rechercher par sens"), {
+      target: { value: "architecture produit" },
+    });
+    fireEvent.submit(screen.getByRole("search", { name: "Recherche sémantique" }));
+
+    await waitFor(() => expect(window.location.search).toContain("semantic=architecture+produit"));
+    unmount();
+    window.history.replaceState(null, "", "/?semantic=architecture%20produit");
+
+    const restoredSearchBookmarks = vi.fn().mockResolvedValue([
+      createBookmark({
+        id: "00000000-0000-4000-8000-000000000004",
+        title: "Restored semantic result",
+      }),
+    ]);
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSearchBookmarks={restoredSearchBookmarks}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(restoredSearchBookmarks).toHaveBeenCalledWith("architecture produit"),
+    );
+    expect(screen.getByLabelText("Rechercher par sens")).toHaveValue("architecture produit");
+    expect(screen.getByRole("article", { name: "Restored semantic result" })).toBeInTheDocument();
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+  });
+
   it("loads the next Bookmark page and appends it to the grid", async () => {
     const loadMoreBookmarks = vi.fn().mockResolvedValue([
       createBookmark({

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,7 +16,7 @@
 - [x] GREEN: sync semantic search query to URL.
 - [x] Refactor only after green.
 - [x] Verify with web tests, typecheck, targeted lint, and build.
-- [ ] Push branch and create draft PR linked with `Closes #40`.
+- [x] Push branch and create draft PR linked with `Closes #40`.
 
 ## Scope
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,33 +1,30 @@
-# Issue #41 - Bookmark Grid Pagination
+# Issue #40 - Semantic Search Bar
 
 ## Plan
 
-- [x] RED: prove initial browse data exposes page size and `hasMoreBookmarks`.
-- [x] GREEN: return pagination metadata from the home loader.
-- [x] RED: prove "Charger plus" fetches the next page with `offset: 48` and appends cards.
-- [x] GREEN: add load-more callback, loading state, and append behavior.
-- [x] RED: prove load trigger is hidden when the returned page is shorter than the limit.
-- [x] GREEN: compute `hasMoreBookmarks` after each page.
-- [x] RED: prove pagination state resets when filters change.
-- [x] GREEN: reset loaded pages to the initial page on filter changes.
-- [x] Refactor only after green.
-- [x] Verify with web tests, typecheck, targeted lint, and build.
-- [x] Push branch and create draft PR linked with `Closes #41`.
+- [ ] RED: prove a distinct semantic search input is visible on the browse page.
+- [ ] GREEN: add the semantic search form shell.
+- [ ] RED: prove submitting a query calls search with the query and replaces the browse grid.
+- [ ] GREEN: wire semantic search callback and search-mode results.
+- [ ] RED: prove a loading state is shown while search is in flight.
+- [ ] GREEN: add semantic search pending state.
+- [ ] RED: prove empty semantic results show an empty state.
+- [ ] GREEN: add search empty state.
+- [ ] RED: prove clearing semantic search restores browse mode.
+- [ ] GREEN: add clear control and browse restore.
+- [ ] RED: prove active semantic query is reflected in the URL and restored on load.
+- [ ] GREEN: sync semantic search query to URL.
+- [ ] Refactor only after green.
+- [ ] Verify with web tests, typecheck, targeted lint, and build.
+- [ ] Push branch and create draft PR linked with `Closes #40`.
 
 ## Scope
 
 - App: `apps/web`.
-- Public interface: Owner loads more Bookmarks from the main browse grid.
-- Trigger: explicit "Charger plus" button.
+- Public interface: Owner searches Bookmarks semantically from the main page.
+- Search mode replaces the browse grid while active.
 - User-facing copy: French.
 
 ## Review
 
-- `pnpm --filter @stashbox/web test` passed: 49 tests.
-- `pnpm --filter @stashbox/web typecheck` passed.
-- Targeted ESLint passed on modified web files.
-- `pnpm --filter @stashbox/web build` passed.
-- Full `pnpm --filter @stashbox/web lint` is blocked by pre-existing generated
-  `apps/web/app.config.timestamp_*.js` import-sort errors and unrelated import
-  order errors outside this change.
-- Draft PR: https://github.com/Nardjo/stashbox/pull/50
+- Pending.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,20 +2,20 @@
 
 ## Plan
 
-- [ ] RED: prove a distinct semantic search input is visible on the browse page.
-- [ ] GREEN: add the semantic search form shell.
-- [ ] RED: prove submitting a query calls search with the query and replaces the browse grid.
-- [ ] GREEN: wire semantic search callback and search-mode results.
-- [ ] RED: prove a loading state is shown while search is in flight.
-- [ ] GREEN: add semantic search pending state.
-- [ ] RED: prove empty semantic results show an empty state.
-- [ ] GREEN: add search empty state.
-- [ ] RED: prove clearing semantic search restores browse mode.
-- [ ] GREEN: add clear control and browse restore.
-- [ ] RED: prove active semantic query is reflected in the URL and restored on load.
-- [ ] GREEN: sync semantic search query to URL.
-- [ ] Refactor only after green.
-- [ ] Verify with web tests, typecheck, targeted lint, and build.
+- [x] RED: prove a distinct semantic search input is visible on the browse page.
+- [x] GREEN: add the semantic search form shell.
+- [x] RED: prove submitting a query calls search with the query and replaces the browse grid.
+- [x] GREEN: wire semantic search callback and search-mode results.
+- [x] RED: prove a loading state is shown while search is in flight.
+- [x] GREEN: add semantic search pending state.
+- [x] RED: prove empty semantic results show an empty state.
+- [x] GREEN: add search empty state.
+- [x] RED: prove clearing semantic search restores browse mode.
+- [x] GREEN: add clear control and browse restore.
+- [x] RED: prove active semantic query is reflected in the URL and restored on load.
+- [x] GREEN: sync semantic search query to URL.
+- [x] Refactor only after green.
+- [x] Verify with web tests, typecheck, targeted lint, and build.
 - [ ] Push branch and create draft PR linked with `Closes #40`.
 
 ## Scope
@@ -27,4 +27,8 @@
 
 ## Review
 
-- Pending.
+- Added a dedicated semantic search form on the browse page.
+- Submitting a query calls the route-provided `searchBookmarks` callback and swaps the browse grid for semantic results.
+- Search mode hides pagination and the add-card, reuses `BookmarkCard` for results, supports loading, empty, clear, and URL restore via `?semantic=...`.
+- Validation passed: `pnpm --filter @stashbox/web test`, `pnpm --filter @stashbox/web typecheck`, targeted `eslint`, `pnpm --filter @stashbox/web build`.
+- Full `pnpm --filter @stashbox/web lint` remains blocked by existing import-sort errors in generated `app.config.timestamp_*.js` and unrelated files.


### PR DESCRIPTION
Closes #40

## Summary

- Add a dedicated semantic search bar to the web browse page.
- Replace browse results with semantic results while a query is active.
- Keep semantic query shareable through the URL.

## Test plan

- [x] TDD tests pass
- [x] Web typecheck passes
- [x] Web build passes
- [x] Targeted lint passes
- [x] Full web lint: blocked by existing import-sort errors in app.config.timestamp_*.js and unrelated files