### PR TITLE
feat: add capture credentials media lifecycle

### DIFF
--- a/apps/api/app/controllers/bookmarks_controller.ts
+++ b/apps/api/app/controllers/bookmarks_controller.ts
@@ -1,13 +1,15 @@
 import { randomUUID } from 'node:crypto'
 
 import type { HttpContext } from '@adonisjs/core/http'
-import { hashUrl, normalizeUrl } from '@stashbox/shared'
-
 import db from '@adonisjs/lucid/services/db'
+import { detectMedia, hashUrl, normalizeUrl } from '@stashbox/shared'
 import vine from '@vinejs/vine'
+import { DateTime } from 'luxon'
 
 import Bookmark from '#models/bookmark'
+import { storeClientCapture, type StoredCapture } from '#services/capture_storage'
 import enrichmentQueue from '#services/enrichment_queue'
+import transcriptionQueue from '#services/transcription_queue'
 import { createBookmarkValidator } from '#validators/bookmark'
 
 const indexValidator = vine.compile(
@@ -80,14 +82,28 @@ export default class BookmarksController {
 
     const url = normalizeUrl(payload.url)
     const urlHash = hashUrl(url)
+    const media = detectMedia(url)
 
     const existing = await Bookmark.findBy('urlHash', urlHash)
     if (existing) {
-      return response.conflict(existing)
+      return response.conflict(serializeBookmarkModel(existing))
+    }
+
+    const id = randomUUID()
+    let capture: StoredCapture | null = null
+    if (payload.capture) {
+      try {
+        capture = await storeClientCapture(id, payload.capture)
+      } catch (error) {
+        return response.status(422).send({
+          error: 'validation_failed',
+          message: error instanceof Error ? error.message : 'Capture is invalid',
+        })
+      }
     }
 
     const bookmark = await Bookmark.create({
-      id: randomUUID(),
+      id,
       url,
       urlHash,
       type: 'other',
@@ -95,20 +111,38 @@ export default class BookmarksController {
       description: '',
       tags: [],
       ogImage: null,
+      capturePath: capture?.path ?? null,
+      captureUrl: capture?.url ?? null,
+      captureSource: capture?.source ?? null,
+      captureMimeType: capture?.mimeType ?? null,
+      captureWidth: capture?.width ?? null,
+      captureHeight: capture?.height ?? null,
+      captureByteSize: capture?.byteSize ?? null,
+      capturedAt: capture?.capturedAt ? DateTime.fromISO(capture.capturedAt) : null,
       embedData: null,
+      isMedia: media.isMedia,
+      mediaKind: media.mediaKind,
+      mediaProvider: media.mediaProvider,
       enrichmentStatus: 'pending',
       enrichmentError: null,
       enrichmentFailureReason: null,
       enrichmentAttempts: 0,
       enrichedAt: null,
       embeddingSourceText: null,
+      transcriptionStatus: media.isMedia ? 'pending' : 'none',
+      transcriptionError: null,
+      transcriptionText: null,
+      transcribedAt: null,
       savedCount: 1,
       savedFrom: payload.sharedFrom ? [payload.sharedFrom] : [],
     })
 
-    await enrichmentQueue.dispatch(bookmark.id, payload.content)
+    await Promise.all([
+      enrichmentQueue.dispatch(bookmark.id, payload.content),
+      media.isMedia ? transcriptionQueue.dispatch(bookmark.id) : Promise.resolve(),
+    ])
 
-    return response.created(bookmark)
+    return response.created(serializeBookmarkModel(bookmark))
   }
 
   async show({ params, response }: HttpContext) {
@@ -116,7 +150,7 @@ export default class BookmarksController {
     if (!bookmark) {
       return response.notFound({ error: 'not_found', message: 'Bookmark not found' })
     }
-    return bookmark
+    return serializeBookmarkModel(bookmark)
   }
 
   async refresh({ params, response }: HttpContext) {
@@ -142,6 +176,47 @@ export default class BookmarksController {
   }
 }
 
+export function serializeBookmarkModel(bookmark: Bookmark): Record<string, unknown> {
+  return {
+    id: bookmark.id,
+    url: bookmark.url,
+    urlHash: bookmark.urlHash,
+    type: bookmark.type,
+    title: bookmark.title,
+    description: bookmark.description,
+    tags: bookmark.tags,
+    embedding: null,
+    ogImage: bookmark.ogImage,
+    capture: serializeCapture({
+      url: bookmark.captureUrl,
+      source: bookmark.captureSource,
+      mimeType: bookmark.captureMimeType,
+      width: bookmark.captureWidth,
+      height: bookmark.captureHeight,
+      byteSize: bookmark.captureByteSize,
+      capturedAt: bookmark.capturedAt,
+    }),
+    embedData: bookmark.embedData,
+    isMedia: bookmark.isMedia,
+    mediaKind: bookmark.mediaKind,
+    mediaProvider: bookmark.mediaProvider,
+    enrichmentStatus: bookmark.enrichmentStatus,
+    enrichmentError: bookmark.enrichmentError,
+    enrichmentFailureReason: bookmark.enrichmentFailureReason,
+    enrichmentAttempts: bookmark.enrichmentAttempts,
+    enrichedAt: toIso(bookmark.enrichedAt),
+    embeddingSourceText: bookmark.embeddingSourceText,
+    transcriptionStatus: bookmark.transcriptionStatus,
+    transcriptionError: bookmark.transcriptionError,
+    transcriptionText: bookmark.transcriptionText,
+    transcribedAt: toIso(bookmark.transcribedAt),
+    savedAt: toIso(bookmark.savedAt),
+    savedCount: bookmark.savedCount,
+    lastSavedAt: toIso(bookmark.lastSavedAt),
+    savedFrom: bookmark.savedFrom,
+  }
+}
+
 export function serializeBookmarkRow(r: Record<string, unknown>): Record<string, unknown> {
   return {
     id: r.id,
@@ -151,18 +226,57 @@ export function serializeBookmarkRow(r: Record<string, unknown>): Record<string,
     title: r.title,
     description: r.description,
     tags: parseTags(r.tags),
+    embedding: null,
     ogImage: r.og_image,
+    capture: serializeCapture({
+      url: r.capture_url,
+      source: r.capture_source,
+      mimeType: r.capture_mime_type,
+      width: r.capture_width,
+      height: r.capture_height,
+      byteSize: r.capture_byte_size,
+      capturedAt: r.captured_at,
+    }),
     embedData: r.embed_data,
+    isMedia: r.is_media,
+    mediaKind: r.media_kind,
+    mediaProvider: r.media_provider,
     enrichmentStatus: r.enrichment_status,
     enrichmentError: r.enrichment_error,
     enrichmentFailureReason: r.enrichment_failure_reason,
     enrichmentAttempts: r.enrichment_attempts,
     enrichedAt: toIso(r.enriched_at),
     embeddingSourceText: r.embedding_source_text,
+    transcriptionStatus: r.transcription_status,
+    transcriptionError: r.transcription_error,
+    transcriptionText: r.transcription_text,
+    transcribedAt: toIso(r.transcribed_at),
     savedAt: toIso(r.saved_at),
     savedCount: r.saved_count,
     lastSavedAt: toIso(r.last_saved_at),
     savedFrom: parseTags(r.saved_from),
+  }
+}
+
+function serializeCapture(input: {
+  url: unknown
+  source: unknown
+  mimeType: unknown
+  width: unknown
+  height: unknown
+  byteSize: unknown
+  capturedAt: unknown
+}): Record<string, unknown> | null {
+  if (!input.url || !input.byteSize || !input.capturedAt) return null
+
+  return {
+    url: input.url,
+    source: input.source ?? 'client',
+    mimeType: input.mimeType ?? 'image/png',
+    width: toNullableNumber(input.width),
+    height: toNullableNumber(input.height),
+    byteSize: Number(input.byteSize),
+    capturedAt: toIso(input.capturedAt),
   }
 }
 
@@ -182,5 +296,14 @@ function parseTags(v: unknown): string[] {
 function toIso(v: unknown): string | null {
   if (v == null) return null
   if (v instanceof Date) return v.toISOString()
+  if (typeof (v as { toISO?: unknown }).toISO === 'function') {
+    return (v as { toISO: () => string | null }).toISO() ?? String(v)
+  }
   return String(v)
+}
+
+function toNullableNumber(v: unknown): number | null {
+  if (v == null) return null
+  const number = Number(v)
+  return Number.isFinite(number) ? number : null
 }

--- a/apps/api/app/controllers/captures_controller.ts
+++ b/apps/api/app/controllers/captures_controller.ts
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises'
+
+import type { HttpContext } from '@adonisjs/core/http'
+import app from '@adonisjs/core/services/app'
+
+const CAPTURE_FILE_PATTERN = /^[0-9a-f-]{36}\.png$/i
+
+export default class CapturesController {
+  async show({ params, response }: HttpContext) {
+    const file = String(params.file ?? '')
+    if (!CAPTURE_FILE_PATTERN.test(file)) {
+      return response.notFound({ error: 'not_found', message: 'Capture not found' })
+    }
+
+    try {
+      const buffer = await readFile(app.makePath('tmp', 'captures', file))
+      return response
+        .header('Content-Type', 'image/png')
+        .header('Cache-Control', 'public, max-age=31536000, immutable')
+        .send(buffer)
+    } catch {
+      return response.notFound({ error: 'not_found', message: 'Capture not found' })
+    }
+  }
+}

--- a/apps/api/app/controllers/site_credentials_controller.ts
+++ b/apps/api/app/controllers/site_credentials_controller.ts
@@ -1,0 +1,106 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import type { SiteCredentialMetadata, SyncSiteCredentialsInput } from '@stashbox/shared'
+import { SyncSiteCredentialsInputSchema } from '@stashbox/shared'
+import { z } from 'zod'
+
+import SiteCredential from '#models/site_credential'
+import { encryptSiteCredentialCookies } from '#services/site_credentials_encryption'
+
+const idSchema = z.string().uuid()
+
+export default class SiteCredentialsController {
+  async index() {
+    const credentials = await SiteCredential.query().orderBy('updated_at', 'desc')
+    return { results: credentials.map(serializeSiteCredential) }
+  }
+
+  async sync({ request, response }: HttpContext) {
+    const parsed = SyncSiteCredentialsInputSchema.safeParse(request.body())
+    if (!parsed.success) {
+      return response.status(422).send({
+        error: 'validation_failed',
+        details: parsed.error.flatten(),
+      })
+    }
+
+    let payload: SyncSiteCredentialsInput
+    try {
+      payload = normalizeSyncPayload(parsed.data)
+    } catch {
+      return response.status(422).send({
+        error: 'validation_failed',
+        message: 'Site credentials domain is invalid',
+      })
+    }
+    const encryptedCookies = encryptSiteCredentialCookies(payload.domain, payload.cookies)
+
+    const credential = await SiteCredential.updateOrCreate(
+      { domain: payload.domain },
+      {
+        domain: payload.domain,
+        encryptedCookies,
+        cookieCount: payload.cookies.length,
+      }
+    )
+
+    return serializeSiteCredential(credential)
+  }
+
+  async show({ params, response }: HttpContext) {
+    const id = idSchema.safeParse(params.id)
+    if (!id.success) {
+      return response.status(422).send({ error: 'validation_failed' })
+    }
+
+    const credential = await SiteCredential.find(id.data)
+    if (!credential) {
+      return response.notFound({ error: 'not_found', message: 'Site credentials not found' })
+    }
+
+    return serializeSiteCredential(credential)
+  }
+
+  async destroy({ params, response }: HttpContext) {
+    const id = idSchema.safeParse(params.id)
+    if (!id.success) {
+      return response.status(422).send({ error: 'validation_failed' })
+    }
+
+    const credential = await SiteCredential.find(id.data)
+    if (!credential) {
+      return response.notFound({ error: 'not_found', message: 'Site credentials not found' })
+    }
+
+    await credential.delete()
+    return response.noContent()
+  }
+}
+
+export function normalizeSiteCredentialDomain(value: string): string {
+  const input = value.trim().toLowerCase()
+  const url = new URL(input.includes('://') ? input : `https://${input}`)
+  const domain = url.hostname.replace(/^\.+/, '')
+
+  if (!domain) {
+    throw new Error('Site credentials domain is required')
+  }
+
+  return domain
+}
+
+export function serializeSiteCredential(credential: SiteCredential): SiteCredentialMetadata {
+  return {
+    id: credential.id,
+    domain: credential.domain,
+    cookieCount: credential.cookieCount,
+    createdAt: credential.createdAt.toISO() ?? credential.createdAt.toString(),
+    updatedAt: credential.updatedAt.toISO() ?? credential.updatedAt.toString(),
+  }
+}
+
+function normalizeSyncPayload(payload: SyncSiteCredentialsInput): SyncSiteCredentialsInput {
+  return {
+    ...payload,
+    domain: normalizeSiteCredentialDomain(payload.domain),
+  }
+}

--- a/apps/api/app/jobs/transcribe_bookmark_job.ts
+++ b/apps/api/app/jobs/transcribe_bookmark_job.ts
@@ -1,0 +1,32 @@
+import { DateTime } from 'luxon'
+
+import Bookmark from '#models/bookmark'
+
+export default class TranscribeBookmarkJob {
+  static async handle(bookmarkId: string): Promise<void> {
+    const bookmark = await Bookmark.find(bookmarkId)
+    if (!bookmark || !bookmark.isMedia || bookmark.transcriptionStatus === 'none') return
+  }
+
+  static async markTranscribing(bookmark: Bookmark): Promise<void> {
+    bookmark.transcriptionStatus = 'transcribing'
+    bookmark.transcriptionError = null
+    await bookmark.save()
+  }
+
+  static async markDone(bookmark: Bookmark, text: string): Promise<void> {
+    bookmark.transcriptionStatus = 'done'
+    bookmark.transcriptionText = text
+    bookmark.transcriptionError = null
+    bookmark.transcribedAt = DateTime.utc()
+    await bookmark.save()
+  }
+
+  static async markFailed(bookmark: Bookmark, error: string): Promise<void> {
+    bookmark.transcriptionStatus = 'failed'
+    bookmark.transcriptionError = error
+    bookmark.transcriptionText = null
+    bookmark.transcribedAt = null
+    await bookmark.save()
+  }
+}

--- a/apps/api/app/models/bookmark.ts
+++ b/apps/api/app/models/bookmark.ts
@@ -3,7 +3,10 @@ import type {
   BookmarkType,
   EnrichmentFailureReason,
   EnrichmentStatus,
+  MediaKind,
+  MediaProvider,
   SavedFrom,
+  TranscriptionStatus,
 } from '@stashbox/shared'
 import { DateTime } from 'luxon'
 
@@ -38,11 +41,44 @@ export default class Bookmark extends BaseModel {
   @column()
   declare ogImage: string | null
 
+  @column()
+  declare capturePath: string | null
+
+  @column()
+  declare captureUrl: string | null
+
+  @column()
+  declare captureSource: 'client' | null
+
+  @column()
+  declare captureMimeType: 'image/png' | null
+
+  @column()
+  declare captureWidth: number | null
+
+  @column()
+  declare captureHeight: number | null
+
+  @column()
+  declare captureByteSize: number | null
+
+  @column.dateTime()
+  declare capturedAt: DateTime | null
+
   @column({
     prepare: (v: unknown) => (v === null || v === undefined ? null : JSON.stringify(v)),
     consume: (v: unknown) => (typeof v === 'string' ? JSON.parse(v) : v),
   })
   declare embedData: unknown | null
+
+  @column()
+  declare isMedia: boolean
+
+  @column()
+  declare mediaKind: MediaKind | null
+
+  @column()
+  declare mediaProvider: MediaProvider | null
 
   @column()
   declare enrichmentStatus: EnrichmentStatus
@@ -61,6 +97,18 @@ export default class Bookmark extends BaseModel {
 
   @column()
   declare embeddingSourceText: string | null
+
+  @column()
+  declare transcriptionStatus: TranscriptionStatus
+
+  @column()
+  declare transcriptionError: string | null
+
+  @column()
+  declare transcriptionText: string | null
+
+  @column.dateTime()
+  declare transcribedAt: DateTime | null
 
   @column.dateTime({ autoCreate: true })
   declare savedAt: DateTime

--- a/apps/api/app/models/site_credential.ts
+++ b/apps/api/app/models/site_credential.ts
@@ -1,0 +1,24 @@
+import { BaseModel, column } from '@adonisjs/lucid/orm'
+import { DateTime } from 'luxon'
+
+export default class SiteCredential extends BaseModel {
+  static table = 'site_credentials'
+
+  @column({ isPrimary: true })
+  declare id: string
+
+  @column()
+  declare domain: string
+
+  @column()
+  declare encryptedCookies: string
+
+  @column()
+  declare cookieCount: number
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/services/capture_storage.ts
+++ b/apps/api/app/services/capture_storage.ts
@@ -1,0 +1,68 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import app from '@adonisjs/core/services/app'
+import type { Capture, ClientCaptureInput } from '@stashbox/shared'
+import { DateTime } from 'luxon'
+
+import { appUrl } from '#config/app'
+
+const PNG_DATA_URL_PREFIX = 'data:image/png;base64,'
+
+export class InvalidCaptureError extends Error {}
+
+export type StoredCapture = Capture & {
+  path: string
+}
+
+export async function storeClientCapture(
+  bookmarkId: string,
+  capture: ClientCaptureInput
+): Promise<StoredCapture> {
+  const buffer = decodePngDataUrl(capture.dataUrl)
+  const directory = app.makePath('tmp', 'captures')
+  const filename = `${bookmarkId}.png`
+  const path = join(directory, filename)
+  const capturedAt = DateTime.utc()
+
+  await mkdir(directory, { recursive: true })
+  await writeFile(path, buffer)
+
+  return {
+    path,
+    url: `${appUrl.replace(/\/$/, '')}/captures/${filename}`,
+    source: 'client',
+    mimeType: 'image/png',
+    width: capture.width ?? null,
+    height: capture.height ?? null,
+    byteSize: buffer.byteLength,
+    capturedAt: capturedAt.toISO() ?? capturedAt.toString(),
+  }
+}
+
+function decodePngDataUrl(value: string): Buffer {
+  if (!value.startsWith(PNG_DATA_URL_PREFIX)) {
+    throw new InvalidCaptureError('Capture must be a PNG data URL')
+  }
+
+  const buffer = Buffer.from(value.slice(PNG_DATA_URL_PREFIX.length), 'base64')
+  if (!isPng(buffer)) {
+    throw new InvalidCaptureError('Capture data is not a PNG image')
+  }
+
+  return buffer
+}
+
+function isPng(buffer: Buffer): boolean {
+  return (
+    buffer.length > 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  )
+}

--- a/apps/api/app/services/site_credentials_encryption.ts
+++ b/apps/api/app/services/site_credentials_encryption.ts
@@ -1,0 +1,57 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto'
+
+import type { SiteCredentialCookie } from '@stashbox/shared'
+
+import env from '#start/env'
+
+const algorithm = 'aes-256-gcm'
+const version = 'v1'
+
+export function encryptSiteCredentialCookies(
+  domain: string,
+  cookies: SiteCredentialCookie[]
+): string {
+  const iv = randomBytes(12)
+  const cipher = createCipheriv(algorithm, encryptionKey(), iv)
+  cipher.setAAD(Buffer.from(domain, 'utf8'))
+
+  const ciphertext = Buffer.concat([cipher.update(JSON.stringify(cookies), 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+
+  return [version, iv, authTag, ciphertext].map(encodePart).join(':')
+}
+
+export function decryptSiteCredentialCookies(
+  domain: string,
+  encryptedCookies: string
+): SiteCredentialCookie[] {
+  const [storedVersion, encodedIv, encodedAuthTag, encodedCiphertext] = encryptedCookies.split(':')
+  if (
+    storedVersion !== version ||
+    !encodedIv ||
+    !encodedAuthTag ||
+    !encodedCiphertext ||
+    encryptedCookies.split(':').length !== 4
+  ) {
+    throw new Error('Unsupported Site credentials ciphertext')
+  }
+
+  const decipher = createDecipheriv(algorithm, encryptionKey(), Buffer.from(encodedIv, 'base64url'))
+  decipher.setAAD(Buffer.from(domain, 'utf8'))
+  decipher.setAuthTag(Buffer.from(encodedAuthTag, 'base64url'))
+
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(encodedCiphertext, 'base64url')),
+    decipher.final(),
+  ]).toString('utf8')
+
+  return JSON.parse(plaintext) as SiteCredentialCookie[]
+}
+
+function encryptionKey(): Buffer {
+  return createHash('sha256').update(env.get('APP_KEY').release()).digest()
+}
+
+function encodePart(value: string | Buffer): string {
+  return typeof value === 'string' ? value : value.toString('base64url')
+}

--- a/apps/api/app/services/transcription_queue.ts
+++ b/apps/api/app/services/transcription_queue.ts
@@ -1,0 +1,72 @@
+import type { Queue, Worker } from 'bullmq'
+
+import TranscribeBookmarkJob from '#jobs/transcribe_bookmark_job'
+import env from '#start/env'
+
+const QUEUE_NAME = 'transcription'
+const JOB_NAME = 'transcribe-bookmark'
+
+interface TranscriptionJobData {
+  bookmarkId: string
+}
+
+class TranscriptionQueueService {
+  private bullQueue: Queue<TranscriptionJobData> | null = null
+  private worker: Worker<TranscriptionJobData> | null = null
+  private inFlight: Promise<void>[] = []
+
+  private get useInProcess(): boolean {
+    return env.get('NODE_ENV') === 'test'
+  }
+
+  private async getBullQueue(): Promise<Queue<TranscriptionJobData>> {
+    if (this.bullQueue) return this.bullQueue
+    const { Queue: BullQueue } = await import('bullmq')
+    this.bullQueue = new BullQueue<TranscriptionJobData>(QUEUE_NAME, {
+      connection: { url: env.get('REDIS_URL') },
+    })
+    return this.bullQueue
+  }
+
+  async dispatch(bookmarkId: string): Promise<void> {
+    if (this.useInProcess) {
+      const promise = TranscribeBookmarkJob.handle(bookmarkId).catch((err) => {
+        console.error('[transcription in-process] job failed', err)
+      })
+      this.inFlight.push(promise)
+      return
+    }
+
+    const queue = await this.getBullQueue()
+    await queue.add(JOB_NAME, { bookmarkId })
+  }
+
+  async flush(): Promise<void> {
+    const pending = this.inFlight
+    this.inFlight = []
+    await Promise.all(pending)
+  }
+
+  async startWorker(): Promise<Worker<TranscriptionJobData>> {
+    if (this.worker) return this.worker
+    const { Worker: BullWorker } = await import('bullmq')
+    this.worker = new BullWorker<TranscriptionJobData>(
+      QUEUE_NAME,
+      async (job) => {
+        await TranscribeBookmarkJob.handle(job.data.bookmarkId)
+      },
+      { connection: { url: env.get('REDIS_URL') } }
+    )
+    return this.worker
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.worker) await this.worker.close()
+    if (this.bullQueue) await this.bullQueue.close()
+    this.worker = null
+    this.bullQueue = null
+  }
+}
+
+const transcriptionQueue = new TranscriptionQueueService()
+export default transcriptionQueue

--- a/apps/api/app/validators/bookmark.ts
+++ b/apps/api/app/validators/bookmark.ts
@@ -16,5 +16,15 @@ export const createBookmarkValidator = vine.compile(
     title: vine.string().optional(),
     content: vine.string().optional(),
     sharedFrom: vine.enum(SAVED_FROM_VALUES).optional(),
+    capture: vine
+      .object({
+        dataUrl: vine
+          .string()
+          .regex(/^data:image\/png;base64,[A-Za-z0-9+/]+={0,2}$/)
+          .maxLength(14_000_000),
+        width: vine.number().positive().max(20_000).optional(),
+        height: vine.number().positive().max(20_000).optional(),
+      })
+      .optional(),
   })
 )

--- a/apps/api/commands/queue_listen.ts
+++ b/apps/api/commands/queue_listen.ts
@@ -3,7 +3,7 @@ import type { CommandOptions } from '@adonisjs/core/types/ace'
 
 export default class QueueListen extends BaseCommand {
   static commandName = 'queue:listen'
-  static description = 'Start the BullMQ worker process for the enrichment queue'
+  static description = 'Start the BullMQ worker processes for enrichment and transcription'
 
   static options: CommandOptions = {
     startApp: true,
@@ -12,20 +12,31 @@ export default class QueueListen extends BaseCommand {
 
   async run() {
     const { default: enrichmentQueue } = await import('#services/enrichment_queue')
-    const worker = await enrichmentQueue.startWorker()
+    const { default: transcriptionQueue } = await import('#services/transcription_queue')
+    const [enrichmentWorker, transcriptionWorker] = await Promise.all([
+      enrichmentQueue.startWorker(),
+      transcriptionQueue.startWorker(),
+    ])
 
-    this.logger.info('Enrichment worker started')
+    this.logger.info('Enrichment and transcription workers started')
 
-    worker.on('completed', (job) => {
-      this.logger.info(`job ${job.id} completed`)
+    enrichmentWorker.on('completed', (job) => {
+      this.logger.info(`enrichment job ${job.id} completed`)
     })
-    worker.on('failed', (job, err) => {
-      this.logger.error(`job ${job?.id} failed: ${err.message}`)
+    enrichmentWorker.on('failed', (job, err) => {
+      this.logger.error(`enrichment job ${job?.id} failed: ${err.message}`)
+    })
+
+    transcriptionWorker.on('completed', (job) => {
+      this.logger.info(`transcription job ${job.id} completed`)
+    })
+    transcriptionWorker.on('failed', (job, err) => {
+      this.logger.error(`transcription job ${job?.id} failed: ${err.message}`)
     })
 
     this.app.terminating(async () => {
-      this.logger.info('shutting down enrichment worker...')
-      await enrichmentQueue.shutdown()
+      this.logger.info('shutting down queue workers...')
+      await Promise.all([enrichmentQueue.shutdown(), transcriptionQueue.shutdown()])
     })
   }
 }

--- a/apps/api/config/bodyparser.ts
+++ b/apps/api/config/bodyparser.ts
@@ -41,6 +41,7 @@ const bodyParserConfig = defineConfig({
       'application/vnd.api+json',
       'application/csp-report',
     ],
+    limit: '15mb',
   },
 
   /**

--- a/apps/api/database/migrations/5_create_site_credentials_table.ts
+++ b/apps/api/database/migrations/5_create_site_credentials_table.ts
@@ -1,0 +1,20 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'site_credentials'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.uuid('id').primary().defaultTo(this.raw('gen_random_uuid()'))
+      table.text('domain').notNullable().unique()
+      table.text('encrypted_cookies').notNullable()
+      table.integer('cookie_count').notNullable().defaultTo(0)
+      table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(this.now())
+      table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(this.now())
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/6_add_capture_fields_to_bookmarks.ts
+++ b/apps/api/database/migrations/6_add_capture_fields_to_bookmarks.ts
@@ -1,0 +1,31 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'bookmarks'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.text('capture_path').nullable()
+      table.text('capture_url').nullable()
+      table.string('capture_source', 16).nullable()
+      table.string('capture_mime_type', 64).nullable()
+      table.integer('capture_width').nullable()
+      table.integer('capture_height').nullable()
+      table.integer('capture_byte_size').nullable()
+      table.timestamp('captured_at', { useTz: true }).nullable()
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('captured_at')
+      table.dropColumn('capture_byte_size')
+      table.dropColumn('capture_height')
+      table.dropColumn('capture_width')
+      table.dropColumn('capture_mime_type')
+      table.dropColumn('capture_source')
+      table.dropColumn('capture_url')
+      table.dropColumn('capture_path')
+    })
+  }
+}

--- a/apps/api/database/migrations/7_add_media_transcription_fields_to_bookmarks.ts
+++ b/apps/api/database/migrations/7_add_media_transcription_fields_to_bookmarks.ts
@@ -1,0 +1,40 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'bookmarks'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.boolean('is_media').notNullable().defaultTo(false)
+      table.string('media_kind', 16).nullable()
+      table.string('media_provider', 32).nullable()
+      table.string('transcription_status', 16).notNullable().defaultTo('none')
+      table.text('transcription_error').nullable()
+      table.text('transcription_text').nullable()
+      table.timestamp('transcribed_at', { useTz: true }).nullable()
+    })
+
+    this.schema.raw(
+      `ALTER TABLE ${this.tableName}
+       ADD CONSTRAINT bookmarks_transcription_status_check
+       CHECK (transcription_status IN ('none', 'pending', 'transcribing', 'done', 'failed'))`
+    )
+  }
+
+  async down() {
+    this.schema.raw(
+      `ALTER TABLE ${this.tableName}
+       DROP CONSTRAINT IF EXISTS bookmarks_transcription_status_check`
+    )
+
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('transcribed_at')
+      table.dropColumn('transcription_text')
+      table.dropColumn('transcription_error')
+      table.dropColumn('transcription_status')
+      table.dropColumn('media_provider')
+      table.dropColumn('media_kind')
+      table.dropColumn('is_media')
+    })
+  }
+}

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -3,10 +3,13 @@ import router from '@adonisjs/core/services/router'
 import { middleware } from '#start/kernel'
 
 const BookmarksController = () => import('#controllers/bookmarks_controller')
+const CapturesController = () => import('#controllers/captures_controller')
 const SearchController = () => import('#controllers/search_controller')
+const SiteCredentialsController = () => import('#controllers/site_credentials_controller')
 const TagsController = () => import('#controllers/tags_controller')
 
 router.get('/', () => ({ ok: true }))
+router.get('/captures/:file', [CapturesController, 'show'])
 
 router
   .group(() => {
@@ -18,5 +21,9 @@ router
     router.post('/bookmarks/:id/refresh', [BookmarksController, 'refresh'])
     router.get('/bookmarks/:id', [BookmarksController, 'show'])
     router.delete('/bookmarks/:id', [BookmarksController, 'destroy'])
+    router.get('/site-credentials', [SiteCredentialsController, 'index'])
+    router.post('/site-credentials/sync', [SiteCredentialsController, 'sync'])
+    router.get('/site-credentials/:id', [SiteCredentialsController, 'show'])
+    router.delete('/site-credentials/:id', [SiteCredentialsController, 'destroy'])
   })
   .use(middleware.authApiKey())

--- a/apps/api/tests/functional/bookmarks.spec.ts
+++ b/apps/api/tests/functional/bookmarks.spec.ts
@@ -1,7 +1,14 @@
+import { randomUUID } from 'node:crypto'
+
 import { test } from '@japa/runner'
 import { hashUrl, normalizeUrl } from '@stashbox/shared'
 
+import TranscribeBookmarkJob from '#jobs/transcribe_bookmark_job'
+import Bookmark from '#models/bookmark'
 import { authHeader } from '#tests/helpers/api_key'
+
+const pngDataUrl =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
 
 test.group('POST /bookmarks', (group) => {
   let auth: { Authorization: string }
@@ -25,7 +32,118 @@ test.group('POST /bookmarks', (group) => {
     assert.equal(body.url, expectedUrl)
     assert.equal(body.urlHash, expectedHash)
     assert.equal(body.enrichmentStatus, 'pending')
+    assert.equal(body.isMedia, false)
+    assert.equal(body.transcriptionStatus, 'none')
     assert.equal(body.savedCount, 1)
+  })
+
+  test('stores one client capture for extension saves', async ({ client, assert }) => {
+    const response = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({
+        url: 'https://example.com/captured',
+        sharedFrom: 'chrome-extension',
+        capture: { dataUrl: pngDataUrl, width: 1280, height: 720 },
+      })
+
+    response.assertStatus(201)
+    const body = response.body()
+    assert.equal(body.capture.source, 'client')
+    assert.equal(body.capture.mimeType, 'image/png')
+    assert.equal(body.capture.width, 1280)
+    assert.equal(body.capture.height, 720)
+    assert.isAbove(body.capture.byteSize, 0)
+
+    const capturePath = new URL(body.capture.url).pathname
+    const image = await client.get(capturePath)
+    image.assertStatus(200)
+    assert.include(String(image.header('content-type')), 'image/png')
+  })
+
+  test('keeps the original capture on dedupe collisions', async ({ client, assert }) => {
+    const first = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({
+        url: 'https://example.com/dedupe-capture?utm_source=one',
+        capture: { dataUrl: pngDataUrl, width: 100, height: 100 },
+      })
+    first.assertStatus(201)
+
+    const second = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({
+        url: 'https://www.example.com/dedupe-capture/',
+        capture: { dataUrl: pngDataUrl, width: 999, height: 999 },
+      })
+
+    second.assertStatus(409)
+    assert.equal(second.body().id, first.body().id)
+    assert.equal(second.body().capture.width, 100)
+    assert.equal(second.body().capture.height, 100)
+  })
+
+  test('marks allowlisted media for transcription without blocking save', async ({
+    client,
+    assert,
+  }) => {
+    const media = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://www.youtube.com/watch?v=abc123' })
+    media.assertStatus(201)
+    assert.equal(media.body().isMedia, true)
+    assert.equal(media.body().mediaKind, 'video')
+    assert.equal(media.body().mediaProvider, 'youtube')
+    assert.equal(media.body().transcriptionStatus, 'pending')
+    assert.equal(media.body().enrichmentStatus, 'pending')
+
+    const article = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://example.com/article-media-test' })
+    article.assertStatus(201)
+    assert.equal(article.body().isMedia, false)
+    assert.equal(article.body().transcriptionStatus, 'none')
+  })
+
+  test('transcription failure does not fail enrichment', async ({ assert }) => {
+    const url = 'https://youtu.be/failure-isolated'
+    const bookmark = await Bookmark.create({
+      id: randomUUID(),
+      url,
+      urlHash: hashUrl(url),
+      type: 'other',
+      title: '',
+      description: '',
+      tags: [],
+      ogImage: null,
+      embedData: null,
+      isMedia: true,
+      mediaKind: 'video',
+      mediaProvider: 'youtube',
+      enrichmentStatus: 'done',
+      enrichmentError: null,
+      enrichmentFailureReason: null,
+      enrichmentAttempts: 0,
+      enrichedAt: null,
+      embeddingSourceText: null,
+      transcriptionStatus: 'pending',
+      transcriptionError: null,
+      transcriptionText: null,
+      transcribedAt: null,
+      savedCount: 1,
+      savedFrom: [],
+    })
+
+    await TranscribeBookmarkJob.markFailed(bookmark, 'provider unavailable')
+    await bookmark.refresh()
+
+    assert.equal(bookmark.transcriptionStatus, 'failed')
+    assert.equal(bookmark.transcriptionError, 'provider unavailable')
+    assert.equal(bookmark.enrichmentStatus, 'done')
   })
 
   test('returns 422 when url is missing or invalid', async ({ client }) => {

--- a/apps/api/tests/functional/site_credentials.spec.ts
+++ b/apps/api/tests/functional/site_credentials.spec.ts
@@ -1,0 +1,108 @@
+import db from '@adonisjs/lucid/services/db'
+import { test } from '@japa/runner'
+
+import { decryptSiteCredentialCookies } from '#services/site_credentials_encryption'
+import { authHeader } from '#tests/helpers/api_key'
+
+const cookie = {
+  name: 'sid',
+  value: 'secret-cookie-value',
+  domain: '.example.com',
+  path: '/',
+  secure: true,
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  expirationDate: 1_893_456_000,
+  session: false,
+  hostOnly: false,
+}
+
+test.group('Site credentials', (group) => {
+  let auth: { Authorization: string }
+  group.each.setup(async () => {
+    auth = await authHeader()
+  })
+
+  test('sync stores cookies encrypted by normalized domain', async ({ client, assert }) => {
+    const response = await client
+      .post('/site-credentials/sync')
+      .headers(auth)
+      .json({ domain: 'https://Example.com/account', cookies: [cookie] })
+
+    response.assertStatus(200)
+    assert.equal(response.body().domain, 'example.com')
+    assert.equal(response.body().cookieCount, 1)
+
+    const row = await db.from('site_credentials').where('domain', 'example.com').first()
+    assert.exists(row)
+    if (!row) return
+    assert.isString(row.encrypted_cookies)
+    assert.isFalse(String(row.encrypted_cookies).includes('secret-cookie-value'))
+    assert.isFalse(String(row.encrypted_cookies).includes('"sid"'))
+
+    const decrypted = decryptSiteCredentialCookies('example.com', row.encrypted_cookies)
+    assert.deepEqual(decrypted, [cookie])
+  })
+
+  test('list and read expose metadata only', async ({ client, assert }) => {
+    const synced = await client
+      .post('/site-credentials/sync')
+      .headers(auth)
+      .json({ domain: 'example.com', cookies: [cookie] })
+    const id = synced.body().id
+
+    const list = await client.get('/site-credentials').headers(auth)
+    list.assertStatus(200)
+    assert.lengthOf(list.body().results, 1)
+    assert.equal(list.body().results[0].cookieCount, 1)
+    assert.isFalse(JSON.stringify(list.body()).includes('secret-cookie-value'))
+    assert.isFalse(JSON.stringify(list.body()).includes('encryptedCookies'))
+
+    const read = await client.get(`/site-credentials/${id}`).headers(auth)
+    read.assertStatus(200)
+    assert.equal(read.body().domain, 'example.com')
+    assert.isFalse(JSON.stringify(read.body()).includes('secret-cookie-value'))
+    assert.isUndefined(read.body().cookies)
+    assert.isUndefined(read.body().encryptedCookies)
+  })
+
+  test('sync updates an existing domain instead of duplicating it', async ({ client, assert }) => {
+    const first = await client
+      .post('/site-credentials/sync')
+      .headers(auth)
+      .json({ domain: 'example.com', cookies: [cookie] })
+
+    const second = await client
+      .post('/site-credentials/sync')
+      .headers(auth)
+      .json({
+        domain: 'https://example.com/profile',
+        cookies: [cookie, { ...cookie, name: 'theme', value: 'dark' }],
+      })
+
+    second.assertStatus(200)
+    assert.equal(second.body().id, first.body().id)
+    assert.equal(second.body().cookieCount, 2)
+
+    const rows = await db.from('site_credentials').where('domain', 'example.com')
+    assert.lengthOf(rows, 1)
+  })
+
+  test('delete removes stored Site credentials', async ({ client, assert }) => {
+    const synced = await client
+      .post('/site-credentials/sync')
+      .headers(auth)
+      .json({ domain: 'example.com', cookies: [cookie] })
+    const id = synced.body().id
+
+    const deleted = await client.delete(`/site-credentials/${id}`).headers(auth)
+    deleted.assertStatus(204)
+
+    const list = await client.get('/site-credentials').headers(auth)
+    list.assertStatus(200)
+    assert.lengthOf(list.body().results, 0)
+
+    const read = await client.get(`/site-credentials/${id}`).headers(auth)
+    read.assertStatus(404)
+  })
+})

--- a/apps/extension/src/lib/siteCredentials.ts
+++ b/apps/extension/src/lib/siteCredentials.ts
@@ -1,0 +1,42 @@
+import type { StashboxClient } from "@stashbox/api-client";
+import type { SiteCredentialCookie, SiteCredentialMetadata } from "@stashbox/shared";
+
+export async function syncCurrentSiteCredentials(
+  client: StashboxClient,
+): Promise<SiteCredentialMetadata> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const siteUrl = getHttpSiteUrl(tab?.url);
+
+  const cookies = await chrome.cookies.getAll({ url: siteUrl.toString() });
+
+  return client.syncSiteCredentials({
+    domain: siteUrl.hostname,
+    cookies: cookies.map(toSiteCredentialCookie),
+  });
+}
+
+function getHttpSiteUrl(value: string | undefined): URL {
+  if (!value) throw new Error("No active tab URL");
+
+  const url = new URL(value);
+  if (!["http:", "https:"].includes(url.protocol)) {
+    throw new Error("Site credentials require an HTTP or HTTPS page");
+  }
+
+  return new URL(`${url.protocol}//${url.host}/`);
+}
+
+function toSiteCredentialCookie(cookie: chrome.cookies.Cookie): SiteCredentialCookie {
+  return {
+    name: cookie.name,
+    value: cookie.value,
+    domain: cookie.domain,
+    path: cookie.path,
+    secure: cookie.secure,
+    httpOnly: cookie.httpOnly,
+    sameSite: cookie.sameSite ?? null,
+    expirationDate: cookie.expirationDate ?? null,
+    session: cookie.session,
+    hostOnly: cookie.hostOnly,
+  };
+}

--- a/apps/extension/src/manifest.json
+++ b/apps/extension/src/manifest.json
@@ -27,6 +27,6 @@
       "run_at": "document_idle"
     }
   ],
-  "permissions": ["activeTab", "storage", "scripting"],
-  "host_permissions": []
+  "permissions": ["activeTab", "storage", "scripting", "cookies"],
+  "host_permissions": ["<all_urls>"]
 }

--- a/apps/extension/src/popup/Popup.tsx
+++ b/apps/extension/src/popup/Popup.tsx
@@ -1,16 +1,19 @@
 import { ApiError, StashboxClient } from "@stashbox/api-client";
-import type { Bookmark } from "@stashbox/shared";
+import type { Bookmark, ClientCaptureInput, SiteCredentialMetadata } from "@stashbox/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useSaveFlow } from "../hooks/useSaveFlow.js";
 import { getOptions, saveOptions } from "../lib/options.js";
 import { pollUntilDone } from "../lib/poll.js";
+import { syncCurrentSiteCredentials } from "../lib/siteCredentials.js";
 
 interface ExtractedContent {
   title: string;
   content: string;
   url: string;
 }
+
+type CredentialSyncState = "idle" | "syncing" | "synced" | "failed";
 
 async function extractFromActiveTab(): Promise<ExtractedContent> {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -38,6 +41,26 @@ async function extractFromActiveTab(): Promise<ExtractedContent> {
     await chrome.scripting.executeScript({ target: { tabId }, files });
     return tryMessage();
   }
+}
+
+async function captureVisibleViewport(): Promise<ClientCaptureInput> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) throw new Error("No active tab");
+
+  const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: "png" });
+  const viewport = await chrome.scripting
+    .executeScript({
+      target: { tabId: tab.id },
+      func: () => ({ width: window.innerWidth, height: window.innerHeight }),
+    })
+    .then((results) => results[0]?.result)
+    .catch(() => undefined);
+
+  return {
+    dataUrl,
+    width: viewport?.width,
+    height: viewport?.height,
+  };
 }
 
 /* ─── Icons ─── */
@@ -86,6 +109,25 @@ function IconSpinner({ className }: { className?: string }) {
         strokeWidth="2.5"
       />
       <path className="opacity-90" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+    </svg>
+  );
+}
+
+function IconKey({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15.75 5.25a4.5 4.5 0 00-4.318 5.764L3 19.446V21h1.554l1.5-1.5h2.25v-2.25h2.25l2.432-2.432A4.5 4.5 0 1015.75 5.25z"
+      />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M17.25 8.25h.008v.008h-.008z" />
     </svg>
   );
 }
@@ -155,6 +197,9 @@ export function Popup() {
   const [ready, setReady] = useState(false);
   const [client, setClient] = useState<StashboxClient | null>(null);
   const [view, setView] = useState<"main" | "settings">("main");
+  const [credentialSyncState, setCredentialSyncState] = useState<CredentialSyncState>("idle");
+  const [credentialSync, setCredentialSync] = useState<SiteCredentialMetadata | null>(null);
+  const [credentialSyncError, setCredentialSyncError] = useState<string | null>(null);
 
   useEffect(() => {
     getOptions().then(({ apiUrl, apiKey }) => {
@@ -166,10 +211,13 @@ export function Popup() {
   const save = useCallback(async (): Promise<Bookmark> => {
     if (!client) throw new Error("Not configured");
     const extracted = await extractFromActiveTab();
+    const capture = await captureVisibleViewport();
     try {
       return await client.add({
         url: extracted.url,
         content: extracted.content || undefined,
+        sharedFrom: "chrome-extension",
+        capture,
       });
     } catch (err) {
       if (err instanceof ApiError && err.status === 409) {
@@ -192,6 +240,23 @@ export function Popup() {
   );
 
   const { state, bookmark, error, trigger } = useSaveFlow({ save, poll });
+
+  const syncCredentials = useCallback(async () => {
+    if (!client) return;
+
+    setCredentialSyncState("syncing");
+    setCredentialSync(null);
+    setCredentialSyncError(null);
+
+    try {
+      const metadata = await syncCurrentSiteCredentials(client);
+      setCredentialSync(metadata);
+      setCredentialSyncState("synced");
+    } catch (err) {
+      setCredentialSyncError(err instanceof Error ? err.message : "Unknown error");
+      setCredentialSyncState("failed");
+    }
+  }, [client]);
 
   const autoTriggered = useRef(false);
   useEffect(() => {
@@ -376,6 +441,37 @@ export function Popup() {
                 </button>
               </div>
             )}
+
+            <div className="archive-panel rounded-sm p-4 animate-fade-up">
+              <div className="flex items-start gap-3">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-sm border border-vault-border bg-vault-elevated/70">
+                  {credentialSyncState === "syncing" ? (
+                    <IconSpinner className="h-5 w-5 animate-spin text-brass-600" />
+                  ) : (
+                    <IconKey className="h-5 w-5 text-brass-600" />
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="technical-label">Identifiants site</p>
+                  <p className="mt-1 font-mono text-xs leading-relaxed text-parchment-200">
+                    {credentialSyncState === "synced" && credentialSync
+                      ? `${credentialSync.domain} · ${credentialSync.cookieCount} cookies synchronisés.`
+                      : credentialSyncState === "failed" && credentialSyncError
+                        ? credentialSyncError
+                        : "Action explicite pour transmettre les cookies du site actif."}
+                  </p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={syncCredentials}
+                disabled={credentialSyncState === "syncing"}
+                className="btn-ghost mt-4 flex w-full items-center justify-center gap-2"
+              >
+                <IconKey className="h-3.5 w-3.5" />
+                {credentialSyncState === "syncing" ? "Synchronisation..." : "Synchroniser cookies"}
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/apps/extension/tests/siteCredentials.test.ts
+++ b/apps/extension/tests/siteCredentials.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { syncCurrentSiteCredentials } from "../src/lib/siteCredentials.js";
+
+const syncSiteCredentials = vi.fn();
+const getAll = vi.fn();
+const query = vi.fn();
+
+vi.stubGlobal("chrome", {
+  tabs: { query },
+  cookies: { getAll },
+});
+
+describe("syncCurrentSiteCredentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("syncs active HTTP site cookies only when called", async () => {
+    query.mockResolvedValue([{ url: "https://example.com/account?x=1" }]);
+    getAll.mockResolvedValue([
+      {
+        name: "sid",
+        value: "secret",
+        domain: ".example.com",
+        path: "/",
+        secure: true,
+        httpOnly: true,
+        sameSite: "lax",
+        expirationDate: undefined,
+        session: true,
+        hostOnly: false,
+      },
+    ]);
+    syncSiteCredentials.mockResolvedValue({
+      id: "650e8400-e29b-41d4-a716-446655440000",
+      domain: "example.com",
+      cookieCount: 1,
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    expect(syncSiteCredentials).not.toHaveBeenCalled();
+
+    const result = await syncCurrentSiteCredentials({ syncSiteCredentials } as never);
+
+    expect(query).toHaveBeenCalledWith({ active: true, currentWindow: true });
+    expect(getAll).toHaveBeenCalledWith({ url: "https://example.com/" });
+    expect(syncSiteCredentials).toHaveBeenCalledWith({
+      domain: "example.com",
+      cookies: [
+        {
+          name: "sid",
+          value: "secret",
+          domain: ".example.com",
+          path: "/",
+          secure: true,
+          httpOnly: true,
+          sameSite: "lax",
+          expirationDate: null,
+          session: true,
+          hostOnly: false,
+        },
+      ],
+    });
+    expect(result.cookieCount).toBe(1);
+  });
+
+  it("rejects browser-internal pages", async () => {
+    query.mockResolvedValue([{ url: "chrome://extensions" }]);
+
+    await expect(syncCurrentSiteCredentials({ syncSiteCredentials } as never)).rejects.toThrow(
+      "Site credentials require an HTTP or HTTPS page",
+    );
+    expect(getAll).not.toHaveBeenCalled();
+    expect(syncSiteCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
@@ -1,5 +1,5 @@
-import type { Bookmark } from "@stashbox/shared";
-import { SlidersHorizontal } from "lucide-react";
+import type { Bookmark, SiteCredentialMetadata } from "@stashbox/shared";
+import { ChevronDown, KeyRound, SlidersHorizontal, Trash2 } from "lucide-react";
 import type { FormEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 
@@ -19,6 +19,7 @@ const bookmarkTypes = ["tweet", "youtube", "article", "image", "pdf", "other"] a
 const searchParamName = "q";
 const legacySemanticSearchParamName = "semantic";
 const allBookmarkTypesValue = "all";
+const emptySiteCredentials: SiteCredentialMetadata[] = [];
 const filterControlClassName =
   "w-full rounded-sm border border-input bg-card/80 px-3 py-2 font-mono text-sm text-foreground shadow-[inset_0_1px_0_oklch(1_0_0/0.04)] outline-none transition placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-60";
 
@@ -26,9 +27,11 @@ type BookmarkBrowsePageProps = {
   bookmarkPageSize?: number;
   bookmarks: Bookmark[];
   hasMoreBookmarks?: boolean;
+  siteCredentials?: SiteCredentialMetadata[];
   loadError?: string;
   onSaveBookmark: (url: string) => Promise<SaveBookmarkResult | void>;
   onDeleteBookmark: (id: string) => Promise<void>;
+  onDeleteSiteCredential?: (id: string) => Promise<void>;
   onLoadMoreBookmarks?: (params: BookmarkPageParams) => Promise<Bookmark[]>;
   onSearchBookmarks?: (query: string) => Promise<Bookmark[]>;
 };
@@ -37,13 +40,18 @@ export function BookmarkBrowsePage({
   bookmarkPageSize = 48,
   bookmarks,
   hasMoreBookmarks = false,
+  siteCredentials = emptySiteCredentials,
   loadError,
   onSaveBookmark,
   onDeleteBookmark,
+  onDeleteSiteCredential,
   onLoadMoreBookmarks,
   onSearchBookmarks,
 }: BookmarkBrowsePageProps) {
   const [visibleBookmarks, setVisibleBookmarks] = useState(bookmarks);
+  const [visibleSiteCredentials, setVisibleSiteCredentials] = useState(siteCredentials);
+  const [isCredentialsOpen, setIsCredentialsOpen] = useState(false);
+  const [deletingCredentialId, setDeletingCredentialId] = useState<string | null>(null);
   const [filters, setFilters] = useState<BookmarkFilters>(getInitialBookmarkFilters);
   const [searchQuery, setSearchQuery] = useState(getInitialSearchQuery);
   const [semanticResults, setSemanticResults] = useState<Bookmark[] | null>(null);
@@ -79,6 +87,10 @@ export function BookmarkBrowsePage({
     setVisibleBookmarks(bookmarks);
     setCanLoadMoreBookmarks(hasMoreBookmarks);
   }, [bookmarks, filters, hasMoreBookmarks, searchQuery]);
+
+  useEffect(() => {
+    setVisibleSiteCredentials(siteCredentials);
+  }, [siteCredentials]);
 
   useEffect(() => {
     setHasLoadedUrlFilters(true);
@@ -120,6 +132,18 @@ export function BookmarkBrowsePage({
   async function handleDeleteBookmark(id: string) {
     await onDeleteBookmark(id);
     setVisibleBookmarks((current) => current.filter((bookmark) => bookmark.id !== id));
+  }
+
+  async function handleDeleteSiteCredential(id: string) {
+    if (!onDeleteSiteCredential || deletingCredentialId) return;
+
+    setDeletingCredentialId(id);
+    try {
+      await onDeleteSiteCredential(id);
+      setVisibleSiteCredentials((current) => current.filter((credential) => credential.id !== id));
+    } finally {
+      setDeletingCredentialId(null);
+    }
   }
 
   async function handleLoadMoreBookmarks() {
@@ -285,6 +309,72 @@ export function BookmarkBrowsePage({
           </div>
         </form>
 
+        <section className="archive-panel overflow-hidden rounded-sm border-border">
+          <button
+            type="button"
+            aria-expanded={isCredentialsOpen}
+            onClick={() => setIsCredentialsOpen((current) => !current)}
+            className="flex w-full items-center justify-between gap-3 p-3 text-left sm:p-4"
+          >
+            <span className="flex min-w-0 items-center gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-sm border border-border bg-card/70 text-primary">
+                <KeyRound aria-hidden="true" className="h-4 w-4" />
+              </span>
+              <span className="min-w-0">
+                <span className="technical-label block">Identifiants site</span>
+                <span className="mt-1 block truncate font-mono text-sm text-muted-foreground">
+                  {visibleSiteCredentials.length === 0
+                    ? "Aucun cookie synchronisé"
+                    : `${visibleSiteCredentials.length} domaine${
+                        visibleSiteCredentials.length > 1 ? "s" : ""
+                      } synchronisé${visibleSiteCredentials.length > 1 ? "s" : ""}`}
+                </span>
+              </span>
+            </span>
+            <ChevronDown
+              aria-hidden="true"
+              className={`h-4 w-4 shrink-0 transition ${isCredentialsOpen ? "rotate-180" : ""}`}
+            />
+          </button>
+          {isCredentialsOpen ? (
+            <div className="border-t border-border p-3 sm:p-4">
+              {visibleSiteCredentials.length === 0 ? (
+                <p className="font-mono text-sm text-muted-foreground">
+                  Synchronisez les cookies depuis l'extension pour les domaines authentifiés.
+                </p>
+              ) : (
+                <ul aria-label="Identifiants site synchronisés" className="grid gap-2">
+                  {visibleSiteCredentials.map((credential) => (
+                    <li
+                      key={credential.id}
+                      className="grid gap-3 rounded-sm border border-border bg-card/60 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate font-mono text-sm font-semibold text-foreground">
+                          {credential.domain}
+                        </p>
+                        <p className="mt-1 font-mono text-xs text-muted-foreground">
+                          {credential.cookieCount} cookies ·{" "}
+                          {formatBookmarkDate(credential.updatedAt)}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => void handleDeleteSiteCredential(credential.id)}
+                        disabled={!onDeleteSiteCredential || deletingCredentialId === credential.id}
+                        className="inline-flex h-10 items-center justify-center gap-2 rounded-sm border border-destructive/50 px-3 font-mono text-xs font-semibold uppercase tracking-[0.14em] text-destructive transition hover:border-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        <Trash2 aria-hidden="true" className="h-3.5 w-3.5" />
+                        {deletingCredentialId === credential.id ? "Suppression..." : "Supprimer"}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ) : null}
+        </section>
+
         {hasEmptySearchResults ? (
           <p className="archive-panel rounded-sm border-border p-8 text-center font-mono text-sm text-muted-foreground">
             Aucun résultat.
@@ -420,6 +510,15 @@ function mergeBookmarks(primaryBookmarks: Bookmark[], secondaryBookmarks: Bookma
   }
 
   return mergedBookmarks;
+}
+
+function formatBookmarkDate(value: string | null) {
+  if (!value) return "Non renseigné";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toISOString().replace("T", " ").replace(".000Z", " UTC");
 }
 
 function isEditableKeyboardTarget(target: EventTarget | null) {

--- a/apps/web/src/components/bookmarks/bookmark-card.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-card.tsx
@@ -18,6 +18,7 @@ export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) 
   const [hasCopiedUrl, setHasCopiedUrl] = useState(false);
   const domain = getDomain(bookmark.url);
   const title = bookmark.title.trim() || domain || bookmark.url;
+  const previewImageUrl = bookmark.capture?.url ?? bookmark.ogImage;
   const isLoading =
     bookmark.enrichmentStatus === "pending" || bookmark.enrichmentStatus === "enriching";
 
@@ -119,10 +120,10 @@ export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) 
           >
             !
           </div>
-        ) : bookmark.ogImage ? (
+        ) : previewImageUrl ? (
           <img
             className="h-full w-full scale-[1.18] object-cover object-center grayscale transition duration-300 group-hover:scale-[1.2] group-hover:grayscale-0"
-            src={bookmark.ogImage}
+            src={previewImageUrl}
             alt={`Aperçu de ${title}`}
           />
         ) : (
@@ -146,6 +147,14 @@ export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) 
               {getStatusLabel(bookmark.enrichmentStatus)}
             </Badge>
             <Badge>{bookmark.type}</Badge>
+            {bookmark.transcriptionStatus && bookmark.transcriptionStatus !== "none" ? (
+              <Badge
+                variant="outline"
+                className={getTranscriptionStatusClassName(bookmark.transcriptionStatus)}
+              >
+                {getTranscriptionStatusLabel(bookmark.transcriptionStatus)}
+              </Badge>
+            ) : null}
           </div>
         </div>
         <h2 className="font-display text-xl font-semibold uppercase leading-none tracking-[-0.01em] text-foreground">
@@ -166,10 +175,10 @@ export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) 
         <DialogContent className="scrollbar-none max-h-[min(90vh,46rem)] max-w-3xl overflow-y-auto overflow-x-hidden p-0">
           <div className="min-w-0">
             <div className="archive-grid-surface h-52 overflow-hidden border-b border-border bg-muted sm:h-60">
-              {bookmark.ogImage ? (
+              {previewImageUrl ? (
                 <img
                   className="h-full w-full scale-[1.08] object-cover object-center grayscale"
-                  src={bookmark.ogImage}
+                  src={previewImageUrl}
                   alt={`Aperçu de ${title}`}
                 />
               ) : (
@@ -192,6 +201,14 @@ export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) 
                     {getStatusLabel(bookmark.enrichmentStatus)}
                   </Badge>
                   <Badge>{bookmark.type}</Badge>
+                  {bookmark.transcriptionStatus && bookmark.transcriptionStatus !== "none" ? (
+                    <Badge
+                      variant="outline"
+                      className={getTranscriptionStatusClassName(bookmark.transcriptionStatus)}
+                    >
+                      {getTranscriptionStatusLabel(bookmark.transcriptionStatus)}
+                    </Badge>
+                  ) : null}
                 </div>
                 <DialogTitle className="text-2xl tracking-[0.02em]">{title}</DialogTitle>
                 <DialogDescription className="break-all">{bookmark.url}</DialogDescription>
@@ -210,6 +227,11 @@ export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) 
                   {formatBookmarkDate(bookmark.enrichedAt)}
                 </DetailItem>
                 <DetailItem label="Tentatives">{bookmark.enrichmentAttempts}</DetailItem>
+                {bookmark.transcriptionStatus ? (
+                  <DetailItem label="Transcription">
+                    {getTranscriptionStatusLabel(bookmark.transcriptionStatus)}
+                  </DetailItem>
+                ) : null}
               </div>
 
               <DetailBlock label="Description">
@@ -237,7 +259,21 @@ export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) 
                 <DetailItem label="Source">
                   {bookmark.savedFrom.length > 0 ? bookmark.savedFrom.join(", ") : "Non renseignée"}
                 </DetailItem>
-                <DetailItem label="Image">
+                <DetailItem label="Capture">
+                  {bookmark.capture ? (
+                    <a
+                      href={bookmark.capture.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="break-all text-primary hover:underline"
+                    >
+                      {bookmark.capture.url}
+                    </a>
+                  ) : (
+                    "Aucune capture."
+                  )}
+                </DetailItem>
+                <DetailItem label="Image OpenGraph">
                   {bookmark.ogImage ? (
                     <a
                       href={bookmark.ogImage}
@@ -252,6 +288,18 @@ export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) 
                   )}
                 </DetailItem>
               </div>
+
+              {bookmark.transcriptionError || bookmark.transcriptionText ? (
+                <DetailBlock label="Transcription média">
+                  {bookmark.transcriptionText ? (
+                    <pre className="max-h-48 max-w-full overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words font-mono text-xs">
+                      {bookmark.transcriptionText}
+                    </pre>
+                  ) : (
+                    bookmark.transcriptionError
+                  )}
+                </DetailBlock>
+              ) : null}
 
               {getEmbedDataSummary(bookmark.embedData).length > 0 ? (
                 <div className="grid gap-2 sm:grid-cols-2">
@@ -385,6 +433,21 @@ function getStatusClassName(status: Bookmark["enrichmentStatus"]) {
   if (status === "degraded") return "border-amber-500/70 text-amber-600 dark:text-amber-300";
 
   return "border-accent text-accent";
+}
+
+function getTranscriptionStatusLabel(status: NonNullable<Bookmark["transcriptionStatus"]>) {
+  if (status === "done") return "Transcrit";
+  if (status === "failed") return "Transcription échouée";
+  if (status === "transcribing") return "Transcription";
+  if (status === "pending") return "À transcrire";
+  return "Sans transcription";
+}
+
+function getTranscriptionStatusClassName(status: NonNullable<Bookmark["transcriptionStatus"]>) {
+  if (status === "done") return "border-[var(--signal)] text-[var(--signal)]";
+  if (status === "failed") return "border-destructive text-destructive";
+  if (status === "transcribing") return "border-accent text-accent";
+  return "border-amber-500/70 text-amber-600 dark:text-amber-300";
 }
 
 function formatBookmarkDate(value: string | null) {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -6,6 +6,7 @@ import type { AddBookmarkResult, InitialBrowseData } from "~/server/stashbox.ts"
 import {
   addBookmark,
   deleteBookmark,
+  deleteSiteCredential,
   listBookmarks,
   loadInitialBrowseData,
   searchBookmarks,
@@ -18,10 +19,11 @@ export const Route = createFileRoute("/")({
 });
 
 function HomePage() {
-  const { bookmarkPageSize, bookmarks, hasMoreBookmarks } =
+  const { bookmarkPageSize, bookmarks, hasMoreBookmarks, siteCredentials } =
     Route.useLoaderData() as InitialBrowseData;
   const saveBookmark = useSaveBookmark();
   const removeBookmark = useDeleteBookmark();
+  const removeSiteCredential = useDeleteSiteCredential();
   const loadMoreBookmarks = useLoadMoreBookmarks();
   const semanticSearchBookmarks = useSearchBookmarks();
 
@@ -30,8 +32,10 @@ function HomePage() {
       bookmarkPageSize={bookmarkPageSize}
       bookmarks={bookmarks}
       hasMoreBookmarks={hasMoreBookmarks}
+      siteCredentials={siteCredentials}
       onSaveBookmark={saveBookmark}
       onDeleteBookmark={removeBookmark}
+      onDeleteSiteCredential={removeSiteCredential}
       onLoadMoreBookmarks={loadMoreBookmarks}
       onSearchBookmarks={semanticSearchBookmarks}
     />
@@ -46,6 +50,7 @@ function HomeErrorPage() {
   return (
     <BookmarkBrowsePage
       bookmarks={[]}
+      siteCredentials={[]}
       loadError="Impossible de charger les Bookmarks."
       onSaveBookmark={saveBookmark}
       onDeleteBookmark={removeBookmark}
@@ -67,6 +72,15 @@ function useSaveBookmark() {
 function useDeleteBookmark() {
   return async (id: string) => {
     await deleteBookmark({ data: { id } });
+  };
+}
+
+function useDeleteSiteCredential() {
+  const router = useRouter();
+
+  return async (id: string) => {
+    await deleteSiteCredential({ data: { id } });
+    await router.invalidate();
   };
 }
 

--- a/apps/web/src/server/stashbox.ts
+++ b/apps/web/src/server/stashbox.ts
@@ -1,6 +1,6 @@
 import type { AddParams, ListParams, SearchParams, Tag } from "@stashbox/api-client";
 import { ApiError, StashboxClient } from "@stashbox/api-client";
-import type { Bookmark } from "@stashbox/shared";
+import type { Bookmark, SiteCredentialMetadata } from "@stashbox/shared";
 import { createServerFn, serverOnly } from "@tanstack/react-start";
 import { z } from "zod";
 
@@ -43,6 +43,10 @@ const deleteBookmarkSchema = z.object({
   id: z.string().uuid(),
 });
 
+const deleteSiteCredentialSchema = z.object({
+  id: z.string().uuid(),
+});
+
 const initialBookmarksPage = { limit: 48, offset: 0 } satisfies ListParams;
 
 let client: StashboxClient | undefined;
@@ -65,6 +69,9 @@ export const createStashboxServerOperations = serverOnly((client = getStashboxSe
     addBookmark: async (params: AddParams) => client.add(addBookmarkSchema.parse(params)),
     deleteBookmark: async ({ id }: { id: string }) =>
       client.delete(deleteBookmarkSchema.parse({ id }).id),
+    listSiteCredentials: async () => client.listSiteCredentials(),
+    deleteSiteCredential: async ({ id }: { id: string }) =>
+      client.deleteSiteCredential(deleteSiteCredentialSchema.parse({ id }).id),
     listTags: async () => client.tags(),
   };
 });
@@ -122,6 +129,15 @@ export const deleteBookmark = createServerFn({ method: "POST" })
   .type("dynamic")
   .handler(async ({ data }) => createStashboxServerOperations().deleteBookmark(data));
 
+export const listSiteCredentials = createServerFn({ method: "GET" })
+  .type("dynamic")
+  .handler(async (): Promise<unknown> => createStashboxServerOperations().listSiteCredentials());
+
+export const deleteSiteCredential = createServerFn({ method: "POST" })
+  .validator((data: { id: string }) => deleteSiteCredentialSchema.parse(data))
+  .type("dynamic")
+  .handler(async ({ data }) => createStashboxServerOperations().deleteSiteCredential(data));
+
 export const listTags = createServerFn({ method: "GET" })
   .type("dynamic")
   .handler(async () => createStashboxServerOperations().listTags());
@@ -130,18 +146,23 @@ export type InitialBrowseData = {
   bookmarkPageSize: number;
   bookmarks: Bookmark[];
   hasMoreBookmarks: boolean;
+  siteCredentials: SiteCredentialMetadata[];
   tags: Tag[];
 };
 
 export const loadInitialBrowseDataFromApi = serverOnly(async (): Promise<InitialBrowseData> => {
   const operations = createStashboxServerOperations();
-  const bookmarks = await operations.listBookmarks(initialBookmarksPage);
-  const tags = await operations.listTags();
+  const [bookmarks, siteCredentials, tags] = await Promise.all([
+    operations.listBookmarks(initialBookmarksPage),
+    operations.listSiteCredentials(),
+    operations.listTags(),
+  ]);
 
   return {
     bookmarkPageSize: initialBookmarksPage.limit,
     bookmarks,
     hasMoreBookmarks: bookmarks.length === initialBookmarksPage.limit,
+    siteCredentials,
     tags,
   };
 });

--- a/apps/web/tests/home-route.test.ts
+++ b/apps/web/tests/home-route.test.ts
@@ -24,6 +24,7 @@ describe("home route", () => {
     vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
       requests.push({ url: String(url), init });
       if (String(url).endsWith("/tags")) return Response.json({ results: tags });
+      if (String(url).endsWith("/site-credentials")) return Response.json({ results: [] });
       return Response.json({ results: bookmarks });
     });
 
@@ -33,10 +34,12 @@ describe("home route", () => {
       bookmarkPageSize: 48,
       bookmarks,
       hasMoreBookmarks: true,
+      siteCredentials: [],
       tags,
     });
     expect(requests.map((request) => request.url)).toEqual([
       "https://stashbox.example/bookmarks?limit=48&offset=0",
+      "https://stashbox.example/site-credentials",
       "https://stashbox.example/tags",
     ]);
   });

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,4 +1,10 @@
-import type { Bookmark, BookmarkType, CreateBookmarkInput } from "@stashbox/shared";
+import type {
+  Bookmark,
+  BookmarkType,
+  CreateBookmarkInput,
+  SiteCredentialMetadata,
+  SyncSiteCredentialsInput,
+} from "@stashbox/shared";
 
 export class ApiError extends Error {
   constructor(
@@ -32,7 +38,9 @@ export interface ListParams {
   tag?: string;
 }
 
-export interface AddParams extends CreateBookmarkInput {}
+export type AddParams = CreateBookmarkInput;
+
+export type SyncSiteCredentialsParams = SyncSiteCredentialsInput;
 
 export interface Tag {
   tag: string;
@@ -91,6 +99,24 @@ export class StashboxClient {
   async tags(minCount?: number): Promise<Tag[]> {
     const res = await this.getQuery<{ results: Tag[] }>("/tags", minCount ? { minCount } : {});
     return res.results;
+  }
+
+  async listSiteCredentials(): Promise<SiteCredentialMetadata[]> {
+    const res = await this.getQuery<{ results: SiteCredentialMetadata[] }>("/site-credentials");
+    return res.results;
+  }
+
+  async getSiteCredential(id: string): Promise<SiteCredentialMetadata> {
+    const res = await this.request("GET", `/site-credentials/${id}`);
+    return res.json() as Promise<SiteCredentialMetadata>;
+  }
+
+  async syncSiteCredentials(params: SyncSiteCredentialsParams): Promise<SiteCredentialMetadata> {
+    return this.post<SiteCredentialMetadata>("/site-credentials/sync", params);
+  }
+
+  async deleteSiteCredential(id: string): Promise<void> {
+    await this.request("DELETE", `/site-credentials/${id}`);
   }
 
   private async post<T>(path: string, body: unknown): Promise<T> {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,2 +1,9 @@
-export { StashboxClient, ApiError } from "./client.js";
-export type { ClientOptions, SearchParams, ListParams, AddParams, Tag } from "./client.js";
+export type {
+  AddParams,
+  ClientOptions,
+  ListParams,
+  SearchParams,
+  SyncSiteCredentialsParams,
+  Tag,
+} from "./client.js";
+export { ApiError, StashboxClient } from "./client.js";

--- a/packages/api-client/tests/client.test.ts
+++ b/packages/api-client/tests/client.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Bookmark, SiteCredentialMetadata } from "@stashbox/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import { StashboxClient } from "../src/client.js";
-import type { Bookmark } from "@stashbox/shared";
 
 const BASE_URL = "http://localhost:3333";
 const API_KEY = "test-key";
@@ -27,6 +28,19 @@ function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
     savedCount: 1,
     lastSavedAt: "2024-01-01T00:00:00.000Z",
     savedFrom: ["cli"],
+    ...overrides,
+  };
+}
+
+function makeSiteCredential(
+  overrides: Partial<SiteCredentialMetadata> = {},
+): SiteCredentialMetadata {
+  return {
+    id: "650e8400-e29b-41d4-a716-446655440000",
+    domain: "example.com",
+    cookieCount: 2,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-02T00:00:00.000Z",
     ...overrides,
   };
 }
@@ -196,6 +210,86 @@ describe("StashboxClient", () => {
 
       const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
       expect(url).toContain("minCount=3");
+    });
+  });
+
+  describe("site credentials", () => {
+    it("lists Site credentials metadata", async () => {
+      const credential = makeSiteCredential();
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({ results: [credential] }) });
+
+      const results = await client.listSiteCredentials();
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`${BASE_URL}/site-credentials`);
+      expect(init.method).toBe("GET");
+      expect(results).toEqual([credential]);
+    });
+
+    it("reads Site credentials metadata", async () => {
+      const credential = makeSiteCredential();
+      fetchMock.mockResolvedValue({ ok: true, json: async () => credential });
+
+      const result = await client.getSiteCredential(credential.id);
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`${BASE_URL}/site-credentials/${credential.id}`);
+      expect(result).toEqual(credential);
+    });
+
+    it("syncs current-site cookies", async () => {
+      const credential = makeSiteCredential({ cookieCount: 1 });
+      fetchMock.mockResolvedValue({ ok: true, json: async () => credential });
+
+      const result = await client.syncSiteCredentials({
+        domain: "example.com",
+        cookies: [
+          {
+            name: "sid",
+            value: "secret",
+            domain: ".example.com",
+            path: "/",
+            secure: true,
+            httpOnly: true,
+            sameSite: "lax",
+            expirationDate: null,
+            session: true,
+            hostOnly: false,
+          },
+        ],
+      });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`${BASE_URL}/site-credentials/sync`);
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual({
+        domain: "example.com",
+        cookies: [
+          {
+            name: "sid",
+            value: "secret",
+            domain: ".example.com",
+            path: "/",
+            secure: true,
+            httpOnly: true,
+            sameSite: "lax",
+            expirationDate: null,
+            session: true,
+            hostOnly: false,
+          },
+        ],
+      });
+      expect(result).toEqual(credential);
+    });
+
+    it("deletes Site credentials by id", async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+      await client.deleteSiteCredential("site-id");
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`${BASE_URL}/site-credentials/site-id`);
+      expect(init.method).toBe("DELETE");
     });
   });
 });

--- a/packages/shared/src/detect-media.ts
+++ b/packages/shared/src/detect-media.ts
@@ -1,0 +1,92 @@
+import type { MediaKind, MediaProvider } from "./schemas.js";
+
+export type MediaDetection =
+  | {
+      isMedia: true;
+      mediaKind: MediaKind;
+      mediaProvider: MediaProvider;
+    }
+  | {
+      isMedia: false;
+      mediaKind: null;
+      mediaProvider: null;
+    };
+
+type MediaRule = {
+  provider: MediaProvider;
+  kind: MediaKind;
+  matches: (url: URL) => boolean;
+};
+
+const NO_MEDIA: MediaDetection = {
+  isMedia: false,
+  mediaKind: null,
+  mediaProvider: null,
+};
+
+const MEDIA_RULES: MediaRule[] = [
+  {
+    provider: "youtube",
+    kind: "video",
+    matches: (url) =>
+      isHost(url, "youtube.com") &&
+      (url.pathname === "/watch" ||
+        url.pathname.startsWith("/shorts/") ||
+        url.pathname.startsWith("/live/") ||
+        url.pathname.startsWith("/embed/")),
+  },
+  {
+    provider: "youtube",
+    kind: "video",
+    matches: (url) => isExactHost(url, "youtu.be") && url.pathname.length > 1,
+  },
+  {
+    provider: "vimeo",
+    kind: "video",
+    matches: (url) =>
+      (isExactHost(url, "vimeo.com") && /^\/\d+/.test(url.pathname)) ||
+      (isExactHost(url, "player.vimeo.com") && /^\/video\/\d+/.test(url.pathname)),
+  },
+  {
+    provider: "soundcloud",
+    kind: "audio",
+    matches: (url) => {
+      if (!isHost(url, "soundcloud.com")) return false;
+      const parts = url.pathname.split("/").filter(Boolean);
+      return parts.length >= 2 && parts[0] !== "discover" && parts[0] !== "search";
+    },
+  },
+  {
+    provider: "spotify",
+    kind: "audio",
+    matches: (url) => isExactHost(url, "open.spotify.com") && url.pathname.startsWith("/episode/"),
+  },
+];
+
+export function detectMedia(input: string): MediaDetection {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return NO_MEDIA;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return NO_MEDIA;
+
+  const rule = MEDIA_RULES.find((candidate) => candidate.matches(url));
+  if (!rule) return NO_MEDIA;
+
+  return {
+    isMedia: true,
+    mediaKind: rule.kind,
+    mediaProvider: rule.provider,
+  };
+}
+
+function isHost(url: URL, baseHost: string): boolean {
+  return isExactHost(url, baseHost) || url.hostname.toLowerCase().endsWith(`.${baseHost}`);
+}
+
+function isExactHost(url: URL, host: string): boolean {
+  return url.hostname.toLowerCase() === host;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,5 @@
+export type { MediaDetection } from "./detect-media.js";
+export { detectMedia } from "./detect-media.js";
 export { detectType } from "./detect-type.js";
 export { hashUrl } from "./hash-url.js";
 export { normalizeUrl } from "./normalize-url.js";
@@ -5,19 +7,37 @@ export type {
   ApiError,
   Bookmark,
   BookmarkType,
+  Capture,
+  ClientCaptureInput,
   CreateBookmarkInput,
   EnrichmentFailureReason,
   EnrichmentStatus,
+  MediaKind,
+  MediaProvider,
   SavedFrom,
   SearchInput,
+  SiteCredentialCookie,
+  SiteCredentialCookieSameSite,
+  SiteCredentialMetadata,
+  SyncSiteCredentialsInput,
+  TranscriptionStatus,
 } from "./schemas.js";
 export {
   ApiErrorSchema,
   BookmarkSchema,
   BookmarkTypeSchema,
+  CaptureSchema,
+  ClientCaptureInputSchema,
   CreateBookmarkInputSchema,
   EnrichmentFailureReasonSchema,
   EnrichmentStatusSchema,
+  MediaKindSchema,
+  MediaProviderSchema,
   SavedFromSchema,
   SearchInputSchema,
+  SiteCredentialCookieSameSiteSchema,
+  SiteCredentialCookieSchema,
+  SiteCredentialMetadataSchema,
+  SyncSiteCredentialsInputSchema,
+  TranscriptionStatusSchema,
 } from "./schemas.js";

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 export const BookmarkTypeSchema = z.enum(["tweet", "youtube", "article", "image", "pdf", "other"]);
 export type BookmarkType = z.infer<typeof BookmarkTypeSchema>;
 
+export const MediaKindSchema = z.enum(["audio", "video"]);
+export type MediaKind = z.infer<typeof MediaKindSchema>;
+
+export const MediaProviderSchema = z.enum(["youtube", "vimeo", "soundcloud", "spotify"]);
+export type MediaProvider = z.infer<typeof MediaProviderSchema>;
+
 export const EnrichmentStatusSchema = z.enum([
   "pending",
   "enriching",
@@ -11,6 +17,15 @@ export const EnrichmentStatusSchema = z.enum([
   "failed",
 ]);
 export type EnrichmentStatus = z.infer<typeof EnrichmentStatusSchema>;
+
+export const TranscriptionStatusSchema = z.enum([
+  "none",
+  "pending",
+  "transcribing",
+  "done",
+  "failed",
+]);
+export type TranscriptionStatus = z.infer<typeof TranscriptionStatusSchema>;
 
 export const EnrichmentFailureReasonSchema = z.enum([
   "url_dead",
@@ -36,6 +51,24 @@ export type SavedFrom = z.infer<typeof SavedFromSchema>;
 const IsoDate = z.string().datetime();
 const UrlHash = z.string().regex(/^[0-9a-f]{64}$/, "must be 64-char lowercase hex");
 
+export const ClientCaptureInputSchema = z.object({
+  dataUrl: z.string().regex(/^data:image\/png;base64,[A-Za-z0-9+/]+={0,2}$/),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
+});
+export type ClientCaptureInput = z.infer<typeof ClientCaptureInputSchema>;
+
+export const CaptureSchema = z.object({
+  url: z.string().url(),
+  source: z.enum(["client"]),
+  mimeType: z.literal("image/png"),
+  width: z.number().int().positive().nullable(),
+  height: z.number().int().positive().nullable(),
+  byteSize: z.number().int().positive(),
+  capturedAt: IsoDate,
+});
+export type Capture = z.infer<typeof CaptureSchema>;
+
 export const BookmarkSchema = z.object({
   id: z.string().uuid(),
   url: z.string().url(),
@@ -46,13 +79,21 @@ export const BookmarkSchema = z.object({
   tags: z.array(z.string()),
   embedding: z.array(z.number()).nullable(),
   ogImage: z.string().url().nullable(),
+  capture: CaptureSchema.nullable().optional(),
   embedData: z.unknown().nullable(),
+  isMedia: z.boolean().optional(),
+  mediaKind: MediaKindSchema.nullable().optional(),
+  mediaProvider: MediaProviderSchema.nullable().optional(),
   enrichmentStatus: EnrichmentStatusSchema,
   enrichmentError: z.string().nullable(),
   enrichmentFailureReason: EnrichmentFailureReasonSchema.nullable(),
   enrichmentAttempts: z.number().int().nonnegative(),
   enrichedAt: IsoDate.nullable(),
   embeddingSourceText: z.string().nullable(),
+  transcriptionStatus: TranscriptionStatusSchema.optional(),
+  transcriptionError: z.string().nullable().optional(),
+  transcriptionText: z.string().nullable().optional(),
+  transcribedAt: IsoDate.nullable().optional(),
   savedAt: IsoDate,
   savedCount: z.number().int().positive(),
   lastSavedAt: IsoDate,
@@ -62,9 +103,49 @@ export type Bookmark = z.infer<typeof BookmarkSchema>;
 
 export const CreateBookmarkInputSchema = z.object({
   url: z.string().url(),
+  title: z.string().optional(),
   content: z.string().optional(),
+  sharedFrom: SavedFromSchema.optional(),
+  capture: ClientCaptureInputSchema.optional(),
 });
 export type CreateBookmarkInput = z.infer<typeof CreateBookmarkInputSchema>;
+
+export const SiteCredentialCookieSameSiteSchema = z.enum([
+  "no_restriction",
+  "lax",
+  "strict",
+  "unspecified",
+]);
+export type SiteCredentialCookieSameSite = z.infer<typeof SiteCredentialCookieSameSiteSchema>;
+
+export const SiteCredentialCookieSchema = z.object({
+  name: z.string().min(1),
+  value: z.string(),
+  domain: z.string().min(1),
+  path: z.string().min(1),
+  secure: z.boolean(),
+  httpOnly: z.boolean(),
+  sameSite: SiteCredentialCookieSameSiteSchema.nullable(),
+  expirationDate: z.number().positive().nullable(),
+  session: z.boolean(),
+  hostOnly: z.boolean(),
+});
+export type SiteCredentialCookie = z.infer<typeof SiteCredentialCookieSchema>;
+
+export const SyncSiteCredentialsInputSchema = z.object({
+  domain: z.string().min(1),
+  cookies: z.array(SiteCredentialCookieSchema).max(500),
+});
+export type SyncSiteCredentialsInput = z.infer<typeof SyncSiteCredentialsInputSchema>;
+
+export const SiteCredentialMetadataSchema = z.object({
+  id: z.string().uuid(),
+  domain: z.string().min(1),
+  cookieCount: z.number().int().nonnegative(),
+  createdAt: IsoDate,
+  updatedAt: IsoDate,
+});
+export type SiteCredentialMetadata = z.infer<typeof SiteCredentialMetadataSchema>;
 
 export const SearchInputSchema = z.object({
   query: z.string().min(1),

--- a/packages/shared/tests/detect-media.test.ts
+++ b/packages/shared/tests/detect-media.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { detectMedia } from "../src/detect-media.js";
+import { detectType } from "../src/detect-type.js";
+
+describe("detectMedia", () => {
+  it.each([
+    ["https://youtube.com/watch?v=abc", "video", "youtube"],
+    ["https://www.youtube.com/shorts/abc", "video", "youtube"],
+    ["https://youtu.be/abc", "video", "youtube"],
+    ["https://vimeo.com/123456", "video", "vimeo"],
+    ["https://player.vimeo.com/video/123456", "video", "vimeo"],
+    ["https://soundcloud.com/artist/track", "audio", "soundcloud"],
+    ["https://open.spotify.com/episode/abc123", "audio", "spotify"],
+  ] as const)("detects allowlisted media from %s", (url, mediaKind, mediaProvider) => {
+    expect(detectMedia(url)).toEqual({
+      isMedia: true,
+      mediaKind,
+      mediaProvider,
+    });
+  });
+
+  it("stays separate from type detection", () => {
+    const url = "https://vimeo.com/123456";
+
+    expect(detectType(url)).toBe("other");
+    expect(detectMedia(url)).toMatchObject({ isMedia: true, mediaProvider: "vimeo" });
+  });
+
+  it.each([
+    "https://example.com/article",
+    "https://cdn.example.com/video.mp4",
+    "https://youtube.com.evil.example/watch?v=abc",
+    "https://open.spotify.com/track/abc123",
+    "ftp://youtube.com/watch?v=abc",
+    "not a url",
+  ])("returns no media for non-allowlisted URL %s", (url) => {
+    expect(detectMedia(url)).toEqual({
+      isMedia: false,
+      mediaKind: null,
+      mediaProvider: null,
+    });
+  });
+});

--- a/packages/shared/tests/schemas.test.ts
+++ b/packages/shared/tests/schemas.test.ts
@@ -4,18 +4,20 @@ import {
   ApiErrorSchema,
   BookmarkSchema,
   BookmarkTypeSchema,
+  CaptureSchema,
+  ClientCaptureInputSchema,
   CreateBookmarkInputSchema,
   EnrichmentStatusSchema,
+  MediaKindSchema,
+  MediaProviderSchema,
   SearchInputSchema,
+  TranscriptionStatusSchema,
 } from "../src/schemas.js";
 
 describe("BookmarkTypeSchema", () => {
-  it.each(["tweet", "youtube", "article", "image", "pdf", "other"])(
-    "accepts %s",
-    (value) => {
-      expect(BookmarkTypeSchema.parse(value)).toBe(value);
-    },
-  );
+  it.each(["tweet", "youtube", "article", "image", "pdf", "other"])("accepts %s", (value) => {
+    expect(BookmarkTypeSchema.parse(value)).toBe(value);
+  });
 
   it("rejects unknown type", () => {
     expect(() => BookmarkTypeSchema.parse("video")).toThrow();
@@ -32,6 +34,26 @@ describe("EnrichmentStatusSchema", () => {
   });
 });
 
+describe("Media schemas", () => {
+  it.each(["audio", "video"])("accepts media kind %s", (value) => {
+    expect(MediaKindSchema.parse(value)).toBe(value);
+  });
+
+  it.each(["youtube", "vimeo", "soundcloud", "spotify"])("accepts provider %s", (value) => {
+    expect(MediaProviderSchema.parse(value)).toBe(value);
+  });
+});
+
+describe("TranscriptionStatusSchema", () => {
+  it.each(["none", "pending", "transcribing", "done", "failed"])("accepts %s", (value) => {
+    expect(TranscriptionStatusSchema.parse(value)).toBe(value);
+  });
+
+  it("rejects unknown status", () => {
+    expect(() => TranscriptionStatusSchema.parse("queued")).toThrow();
+  });
+});
+
 describe("CreateBookmarkInputSchema", () => {
   it("accepts a minimal payload with just a URL", () => {
     const out = CreateBookmarkInputSchema.parse({ url: "https://example.com/" });
@@ -44,6 +66,29 @@ describe("CreateBookmarkInputSchema", () => {
       content: "<article>hello</article>",
     });
     expect(out.content).toBe("<article>hello</article>");
+  });
+
+  it("accepts optional client capture metadata", () => {
+    const out = CreateBookmarkInputSchema.parse({
+      url: "https://example.com/",
+      sharedFrom: "chrome-extension",
+      capture: {
+        dataUrl: "data:image/png;base64,iVBORw0KGgo=",
+        width: 1200,
+        height: 800,
+      },
+    });
+
+    expect(out.capture?.dataUrl).toMatch(/^data:image\/png;base64,/);
+    expect(out.capture?.width).toBe(1200);
+  });
+
+  it("rejects non-PNG client capture payloads", () => {
+    expect(() =>
+      ClientCaptureInputSchema.parse({
+        dataUrl: "data:image/jpeg;base64,AAAA",
+      }),
+    ).toThrow();
   });
 
   it("rejects missing url", () => {
@@ -104,13 +149,21 @@ describe("BookmarkSchema", () => {
     tags: ["greeting"],
     embedding: null,
     ogImage: null,
+    capture: null,
     embedData: null,
+    isMedia: false,
+    mediaKind: null,
+    mediaProvider: null,
     enrichmentStatus: "done",
     enrichmentError: null,
     enrichmentFailureReason: null,
     enrichmentAttempts: 1,
     enrichedAt: "2026-04-27T10:00:00.000Z",
     embeddingSourceText: null,
+    transcriptionStatus: "none",
+    transcriptionError: null,
+    transcriptionText: null,
+    transcribedAt: null,
     savedAt: "2026-04-27T09:00:00.000Z",
     savedCount: 1,
     lastSavedAt: "2026-04-27T09:00:00.000Z",
@@ -119,6 +172,20 @@ describe("BookmarkSchema", () => {
 
   it("accepts a fully-formed bookmark", () => {
     expect(() => BookmarkSchema.parse(valid)).not.toThrow();
+  });
+
+  it("accepts capture metadata on a bookmark", () => {
+    const capture = CaptureSchema.parse({
+      url: "http://localhost:3334/captures/550e8400-e29b-41d4-a716-446655440000.png",
+      source: "client",
+      mimeType: "image/png",
+      width: 1200,
+      height: 800,
+      byteSize: 128,
+      capturedAt: "2026-05-10T10:00:00.000Z",
+    });
+
+    expect(BookmarkSchema.parse({ ...valid, capture }).capture).toEqual(capture);
   });
 
   it("rejects an invalid urlHash length", () => {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,78 @@
+# Parallel Implementation: Issues #54, #56, #58
+
+## Plan
+
+- [x] Launch parallel workers for #54 Client Capture, #56 Site credentials, and #58 Media detection.
+- [x] Prepare shared integration contracts for Bookmark fields and API serialization.
+- [x] Integrate #54 changes and verify extension/API/Web behavior.
+- [x] Integrate #56 changes and verify credential sync/API/Web behavior.
+- [x] Integrate #58 changes and verify media detection/transcription lifecycle behavior.
+- [x] Resolve conflicts across shared schemas, controllers, tests, and UI.
+- [x] Run focused tests, typechecks, lint, and browser verification.
+
+## Scope
+
+- Issues: #54, #56, #58.
+- Apps/packages: `apps/api`, `apps/extension`, `apps/web`, `packages/shared`, `packages/api-client`.
+- Keep #55 Server Capture, #57 authenticated Server Capture, #59 Groq transcription worker, and later slices out of scope.
+
+---
+
+# Issue 58 Media Detection And Transcription Lifecycle
+
+## Plan
+
+- [ ] Add shared allowlist-based Media detection separate from Bookmark Type.
+- [ ] Add Bookmark transcription status/result/error contracts.
+- [ ] Persist Media and transcription fields in the API.
+- [ ] Enqueue placeholder transcription work for Media Bookmarks without blocking Save or Enrichment.
+- [ ] Keep transcription failures isolated from `enrichmentStatus`.
+- [ ] Surface transcription status/errors in the Web App.
+- [ ] Add focused shared/API/Web tests and run verification.
+
+## Scope
+
+- Apps/packages: `packages/shared`, `apps/api`, `apps/web`.
+- Out of scope: Capture, Site credentials, actual Groq transcription worker.
+
+## Review
+
+- Added allowlist media detection in shared code, separate from Bookmark Type.
+- API now persists media metadata and transcription lifecycle fields.
+- Media saves enqueue placeholder transcription work without blocking Save or changing enrichment status.
+- Web cards/details surface transcription status/errors.
+- Verified with shared tests, API suite, Web tests, and targeted typechecks.
+
+---
+
+# Site Credentials Sync
+
+## Plan
+
+- [ ] Add encrypted Site credentials persistence keyed by normalized domain.
+- [ ] Add authenticated sync/list/read/delete API returning metadata only.
+- [ ] Add API client/shared types for Site credentials metadata and sync payloads.
+- [ ] Add explicit extension action to sync current-site cookies without coupling to Bookmark save.
+- [ ] Add Web App management UI to list and delete stored Site credentials.
+- [ ] Add focused API, client, extension, and Web App tests.
+- [ ] Verify targeted tests, typecheck/lint where feasible, and `git diff --check`.
+
+## Scope
+
+- Apps: `apps/api`, `apps/extension`, `apps/web`.
+- Shared/client packages only for cross-app request/response types.
+- Out of scope: Capture storage integration and media detection/transcription use.
+
+## Review
+
+- Added encrypted Site credentials storage keyed by normalized domain.
+- Added authenticated sync/list/read/delete API and API client methods returning metadata only.
+- Extension now has an explicit current-site cookie sync action, separate from Bookmark Save.
+- Web App now has a collapsible Identifiants site section for list/delete.
+- Verified with API, API client, extension, Web tests, and targeted typechecks.
+
+---
+
 # Extension Web Design Alignment
 
 ## Plan
@@ -20,6 +95,33 @@
 - Popup success and settings states were visually verified with a mocked extension runtime.
 - Options page was visually verified from the built extension output.
 - Validation passed: extension build, tests, typecheck, lint, and `git diff --check`.
+
+---
+
+# Issue 54 - Extension Client Capture
+
+## Plan
+
+- [ ] Add nullable Capture metadata to the shared Bookmark contract and API create payload.
+- [ ] Persist one normalized local Capture image only when `/bookmarks` creates a new Bookmark.
+- [ ] Keep dedupe/conflict saves from replacing an existing Capture.
+- [ ] Capture the visible viewport in the extension save flow and send it with the save request.
+- [ ] Prefer Capture over `ogImage` in Web App card and detail previews.
+- [ ] Add focused shared/client/API/extension/web tests.
+- [ ] Run targeted verification and record results.
+
+## Scope
+
+- Apps/packages: `apps/extension`, `apps/api`, `apps/web`, `packages/shared`, `packages/api-client`.
+- Excluded: Site credentials, Media detection/transcription, Server Capture, full-page/multi-variant capture.
+
+## Review
+
+- Extension Save captures the visible viewport as a PNG and sends it with the Bookmark create request.
+- API stores one local Capture for new Bookmarks, exposes metadata, and serves the image under `/captures/:file`.
+- Dedupe conflict responses keep the original Capture and do not overwrite it.
+- Web cards/details prefer Capture over OpenGraph images.
+- Verified with shared/API/API-client/extension/Web tests and targeted typechecks.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds extension captures, encrypted site credentials, and media transcription lifecycle support across Stashbox.

Closes #54.
Closes #56.
Closes #58.

## Changes

- `apps/api/app/controllers/bookmarks_controller.ts` — persist capture/media/transcription fields and serialize new Bookmark metadata
- `apps/api/tests/functional/bookmarks.spec.ts` — cover capture storage, dedupe preservation, media detection, and transcription isolation
- `apps/api/app/controllers/site_credentials_controller.ts` — add Site credentials sync/list/read/delete API
- `apps/api/tests/functional/site_credentials.spec.ts` — verify encryption, metadata-only reads, updates, and deletion
- `apps/web/src/components/bookmarks/bookmark-browse-page.tsx` — add collapsible Site credentials management section
- `apps/extension/src/popup/Popup.tsx` — capture visible viewport on Save and expose explicit cookie sync action
- `packages/api-client/tests/client.test.ts` — cover Site credentials client methods
- `packages/shared/src/detect-media.ts` — add allowlist-based media detection separate from Bookmark Type
- `packages/shared/src/schemas.ts` — add capture, Site credentials, media, and transcription contracts
- `apps/api/app/services/transcription_queue.ts` — add placeholder transcription queue service
- …and 26 more

## Test plan

- [x] CI passes
- [x] Verify migrations run cleanly on a self-hosted instance