### PR TITLE
fix: stabilize bookmark media flows

### DIFF
--- a/apps/api/app/controllers/bookmarks_controller.ts
+++ b/apps/api/app/controllers/bookmarks_controller.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { basename } from 'node:path'
 
 import type { HttpContext } from '@adonisjs/core/http'
 import db from '@adonisjs/lucid/services/db'
@@ -10,6 +11,7 @@ import Bookmark from '#models/bookmark'
 import { storeClientCapture, type StoredCapture } from '#services/capture_storage'
 import enrichmentQueue from '#services/enrichment_queue'
 import transcriptionQueue from '#services/transcription_queue'
+import { getYouTubeThumbnailUrl } from '#services/youtube_thumbnail'
 import { createBookmarkValidator } from '#validators/bookmark'
 
 const indexValidator = vine.compile(
@@ -43,7 +45,7 @@ export default class BookmarksController {
       params
     )
     const rows: Array<Record<string, unknown>> = result.rows ?? result
-    return { results: rows.map(serializeBookmarkRow) }
+    return { results: rows.map((row) => serializeBookmarkRow(row, getRequestBaseUrl(request))) }
   }
 
   async index({ request }: HttpContext) {
@@ -74,7 +76,7 @@ export default class BookmarksController {
       params
     )
     const rows: Array<Record<string, unknown>> = result.rows ?? result
-    return { results: rows.map(serializeBookmarkRow) }
+    return { results: rows.map((row) => serializeBookmarkRow(row, getRequestBaseUrl(request))) }
   }
 
   async store({ request, response }: HttpContext) {
@@ -83,17 +85,19 @@ export default class BookmarksController {
     const url = normalizeUrl(payload.url)
     const urlHash = hashUrl(url)
     const media = detectMedia(url)
+    const captureBaseUrl = getRequestBaseUrl(request)
+    const initialOgImage = media.mediaProvider === 'youtube' ? getYouTubeThumbnailUrl(url) : null
 
     const existing = await Bookmark.findBy('urlHash', urlHash)
     if (existing) {
-      return response.conflict(serializeBookmarkModel(existing))
+      return response.conflict(serializeBookmarkModel(existing, captureBaseUrl))
     }
 
     const id = randomUUID()
     let capture: StoredCapture | null = null
-    if (payload.capture) {
+    if (payload.capture && media.mediaProvider !== 'youtube') {
       try {
-        capture = await storeClientCapture(id, payload.capture)
+        capture = await storeClientCapture(id, payload.capture, captureBaseUrl)
       } catch (error) {
         return response.status(422).send({
           error: 'validation_failed',
@@ -110,7 +114,7 @@ export default class BookmarksController {
       title: payload.title ?? '',
       description: '',
       tags: [],
-      ogImage: null,
+      ogImage: initialOgImage,
       capturePath: capture?.path ?? null,
       captureUrl: capture?.url ?? null,
       captureSource: capture?.source ?? null,
@@ -142,15 +146,15 @@ export default class BookmarksController {
       media.isMedia ? transcriptionQueue.dispatch(bookmark.id) : Promise.resolve(),
     ])
 
-    return response.created(serializeBookmarkModel(bookmark))
+    return response.created(serializeBookmarkModel(bookmark, captureBaseUrl))
   }
 
-  async show({ params, response }: HttpContext) {
+  async show({ params, request, response }: HttpContext) {
     const bookmark = await Bookmark.find(params.id)
     if (!bookmark) {
       return response.notFound({ error: 'not_found', message: 'Bookmark not found' })
     }
-    return serializeBookmarkModel(bookmark)
+    return serializeBookmarkModel(bookmark, getRequestBaseUrl(request))
   }
 
   async refresh({ params, response }: HttpContext) {
@@ -176,7 +180,10 @@ export default class BookmarksController {
   }
 }
 
-export function serializeBookmarkModel(bookmark: Bookmark): Record<string, unknown> {
+export function serializeBookmarkModel(
+  bookmark: Bookmark,
+  captureBaseUrl?: string
+): Record<string, unknown> {
   return {
     id: bookmark.id,
     url: bookmark.url,
@@ -186,16 +193,25 @@ export function serializeBookmarkModel(bookmark: Bookmark): Record<string, unkno
     description: bookmark.description,
     tags: bookmark.tags,
     embedding: null,
-    ogImage: bookmark.ogImage,
-    capture: serializeCapture({
-      url: bookmark.captureUrl,
-      source: bookmark.captureSource,
-      mimeType: bookmark.captureMimeType,
-      width: bookmark.captureWidth,
-      height: bookmark.captureHeight,
-      byteSize: bookmark.captureByteSize,
-      capturedAt: bookmark.capturedAt,
-    }),
+    ogImage: serializeOgImage(
+      bookmark.url,
+      bookmark.ogImage,
+      bookmark.mediaProvider,
+      bookmark.type
+    ),
+    capture: serializeCapture(
+      {
+        path: bookmark.capturePath,
+        url: bookmark.captureUrl,
+        source: bookmark.captureSource,
+        mimeType: bookmark.captureMimeType,
+        width: bookmark.captureWidth,
+        height: bookmark.captureHeight,
+        byteSize: bookmark.captureByteSize,
+        capturedAt: bookmark.capturedAt,
+      },
+      captureBaseUrl
+    ),
     embedData: bookmark.embedData,
     isMedia: bookmark.isMedia,
     mediaKind: bookmark.mediaKind,
@@ -217,7 +233,10 @@ export function serializeBookmarkModel(bookmark: Bookmark): Record<string, unkno
   }
 }
 
-export function serializeBookmarkRow(r: Record<string, unknown>): Record<string, unknown> {
+export function serializeBookmarkRow(
+  r: Record<string, unknown>,
+  captureBaseUrl?: string
+): Record<string, unknown> {
   return {
     id: r.id,
     url: r.url,
@@ -227,16 +246,20 @@ export function serializeBookmarkRow(r: Record<string, unknown>): Record<string,
     description: r.description,
     tags: parseTags(r.tags),
     embedding: null,
-    ogImage: r.og_image,
-    capture: serializeCapture({
-      url: r.capture_url,
-      source: r.capture_source,
-      mimeType: r.capture_mime_type,
-      width: r.capture_width,
-      height: r.capture_height,
-      byteSize: r.capture_byte_size,
-      capturedAt: r.captured_at,
-    }),
+    ogImage: serializeOgImage(r.url, r.og_image, r.media_provider, r.type),
+    capture: serializeCapture(
+      {
+        path: r.capture_path,
+        url: r.capture_url,
+        source: r.capture_source,
+        mimeType: r.capture_mime_type,
+        width: r.capture_width,
+        height: r.capture_height,
+        byteSize: r.capture_byte_size,
+        capturedAt: r.captured_at,
+      },
+      captureBaseUrl
+    ),
     embedData: r.embed_data,
     isMedia: r.is_media,
     mediaKind: r.media_kind,
@@ -258,19 +281,24 @@ export function serializeBookmarkRow(r: Record<string, unknown>): Record<string,
   }
 }
 
-function serializeCapture(input: {
-  url: unknown
-  source: unknown
-  mimeType: unknown
-  width: unknown
-  height: unknown
-  byteSize: unknown
-  capturedAt: unknown
-}): Record<string, unknown> | null {
-  if (!input.url || !input.byteSize || !input.capturedAt) return null
+function serializeCapture(
+  input: {
+    path: unknown
+    url: unknown
+    source: unknown
+    mimeType: unknown
+    width: unknown
+    height: unknown
+    byteSize: unknown
+    capturedAt: unknown
+  },
+  captureBaseUrl?: string
+): Record<string, unknown> | null {
+  const url = buildCaptureUrl(input.url, input.path, captureBaseUrl)
+  if (!url || !input.byteSize || !input.capturedAt) return null
 
   return {
-    url: input.url,
+    url,
     source: input.source ?? 'client',
     mimeType: input.mimeType ?? 'image/png',
     width: toNullableNumber(input.width),
@@ -278,6 +306,39 @@ function serializeCapture(input: {
     byteSize: Number(input.byteSize),
     capturedAt: toIso(input.capturedAt),
   }
+}
+
+function buildCaptureUrl(storedUrl: unknown, storedPath: unknown, baseUrl?: string): string | null {
+  if (!baseUrl) return storedUrl ? String(storedUrl) : null
+
+  const origin = baseUrl.replace(/\/$/, '')
+  if (typeof storedUrl === 'string' && storedUrl.length > 0) {
+    try {
+      return `${origin}${new URL(storedUrl).pathname}`
+    } catch {
+      return storedUrl.startsWith('/captures/') ? `${origin}${storedUrl}` : storedUrl
+    }
+  }
+
+  if (typeof storedPath === 'string' && storedPath.length > 0) {
+    return `${origin}/captures/${basename(storedPath)}`
+  }
+
+  return null
+}
+
+function serializeOgImage(
+  url: unknown,
+  ogImage: unknown,
+  mediaProvider: unknown,
+  type: unknown
+): string | null {
+  if (typeof ogImage === 'string' && ogImage.length > 0) return ogImage
+  if ((mediaProvider === 'youtube' || type === 'youtube') && typeof url === 'string') {
+    return getYouTubeThumbnailUrl(url)
+  }
+
+  return null
 }
 
 function parseTags(v: unknown): string[] {
@@ -291,6 +352,10 @@ function parseTags(v: unknown): string[] {
     }
   }
   return []
+}
+
+function getRequestBaseUrl(request: HttpContext['request']): string {
+  return `${request.protocol()}://${request.host() ?? 'localhost'}`
 }
 
 function toIso(v: unknown): string | null {

--- a/apps/api/app/jobs/enrich_bookmark_job.ts
+++ b/apps/api/app/jobs/enrich_bookmark_job.ts
@@ -53,8 +53,9 @@ export default class EnrichBookmarkJob {
         fallback: bookmark.title || bookmark.url,
       })
 
+      if (fetched?.ogImage) bookmark.ogImage = fetched.ogImage
+
       if (fetched?.kind === 'success') {
-        if (fetched.ogImage) bookmark.ogImage = fetched.ogImage
         if (fetched.embedData !== undefined) bookmark.embedData = fetched.embedData
       }
 

--- a/apps/api/app/services/capture_storage.ts
+++ b/apps/api/app/services/capture_storage.ts
@@ -17,7 +17,8 @@ export type StoredCapture = Capture & {
 
 export async function storeClientCapture(
   bookmarkId: string,
-  capture: ClientCaptureInput
+  capture: ClientCaptureInput,
+  baseUrl = appUrl
 ): Promise<StoredCapture> {
   const buffer = decodePngDataUrl(capture.dataUrl)
   const directory = app.makePath('tmp', 'captures')
@@ -30,7 +31,7 @@ export async function storeClientCapture(
 
   return {
     path,
-    url: `${appUrl.replace(/\/$/, '')}/captures/${filename}`,
+    url: `${baseUrl.replace(/\/$/, '')}/captures/${filename}`,
     source: 'client',
     mimeType: 'image/png',
     width: capture.width ?? null,

--- a/apps/api/app/services/fetch_provider.ts
+++ b/apps/api/app/services/fetch_provider.ts
@@ -1,5 +1,6 @@
 import type { BookmarkType } from '@stashbox/shared'
 
+import { getYouTubeThumbnailUrl } from '#services/youtube_thumbnail'
 import env from '#start/env'
 
 export type FetchOutcome =
@@ -80,11 +81,13 @@ async function fetchTweet(url: string): Promise<FetchOutcome> {
 }
 
 async function fetchYouTube(url: string): Promise<FetchOutcome> {
+  const thumbnailUrl = getYouTubeThumbnailUrl(url)
   const oembed = `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`
   try {
     const res = await fetchWithTimeout(oembed, {}, FETCH_TIMEOUT_MS)
     if (res.status === 404) return { kind: 'dead', reason: 'url_dead' }
-    if (!res.ok) return { kind: 'meta_only', reason: 'transient' }
+    if (!res.ok)
+      return { kind: 'meta_only', reason: 'transient', ogImage: thumbnailUrl ?? undefined }
     const data = (await res.json()) as {
       title?: string
       author_name?: string
@@ -95,10 +98,10 @@ async function fetchYouTube(url: string): Promise<FetchOutcome> {
       kind: 'success',
       content,
       embedData: data,
-      ogImage: data.thumbnail_url,
+      ogImage: data.thumbnail_url ?? thumbnailUrl ?? undefined,
     }
   } catch {
-    return { kind: 'meta_only', reason: 'transient' }
+    return { kind: 'meta_only', reason: 'transient', ogImage: thumbnailUrl ?? undefined }
   }
 }
 

--- a/apps/api/app/services/youtube_thumbnail.ts
+++ b/apps/api/app/services/youtube_thumbnail.ts
@@ -1,0 +1,40 @@
+const YOUTUBE_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/
+
+export function getYouTubeThumbnailUrl(input: string): string | null {
+  const videoId = getYouTubeVideoId(input)
+  return videoId ? `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg` : null
+}
+
+function getYouTubeVideoId(input: string): string | null {
+  let url: URL
+  try {
+    url = new URL(input)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+
+  const host = url.hostname.toLowerCase()
+  if (host === 'youtu.be') {
+    return pickValidId(url.pathname.split('/').filter(Boolean)[0])
+  }
+
+  if (host !== 'youtube.com' && !host.endsWith('.youtube.com')) return null
+
+  if (url.pathname === '/watch') {
+    return pickValidId(url.searchParams.get('v'))
+  }
+
+  const [section, id] = url.pathname.split('/').filter(Boolean)
+  if (section === 'shorts' || section === 'embed' || section === 'live') {
+    return pickValidId(id)
+  }
+
+  return null
+}
+
+function pickValidId(value: string | null | undefined): string | null {
+  if (!value) return null
+  return YOUTUBE_ID_PATTERN.test(value) ? value : null
+}

--- a/apps/api/database/schema.ts
+++ b/apps/api/database/schema.ts
@@ -26,6 +26,14 @@ export class ApiKeySchema extends BaseModel {
 
 export class BookmarkSchema extends BaseModel {
   static $columns = [
+    'captureByteSize',
+    'captureHeight',
+    'captureMimeType',
+    'capturePath',
+    'captureSource',
+    'captureUrl',
+    'captureWidth',
+    'capturedAt',
     'description',
     'embedData',
     'embedding',
@@ -36,18 +44,41 @@ export class BookmarkSchema extends BaseModel {
     'enrichmentFailureReason',
     'enrichmentStatus',
     'id',
+    'isMedia',
     'lastSavedAt',
+    'mediaKind',
+    'mediaProvider',
     'ogImage',
     'savedAt',
     'savedCount',
     'savedFrom',
     'tags',
     'title',
+    'transcribedAt',
+    'transcriptionError',
+    'transcriptionStatus',
+    'transcriptionText',
     'type',
     'url',
     'urlHash',
   ] as const
   $columns = BookmarkSchema.$columns
+  @column()
+  declare captureByteSize: number | null
+  @column()
+  declare captureHeight: number | null
+  @column()
+  declare captureMimeType: string | null
+  @column()
+  declare capturePath: string | null
+  @column()
+  declare captureSource: string | null
+  @column()
+  declare captureUrl: string | null
+  @column()
+  declare captureWidth: number | null
+  @column.dateTime()
+  declare capturedAt: DateTime | null
   @column()
   declare description: string
   @column()
@@ -68,8 +99,14 @@ export class BookmarkSchema extends BaseModel {
   declare enrichmentStatus: string
   @column({ isPrimary: true })
   declare id: string
+  @column()
+  declare isMedia: boolean
   @column.dateTime()
   declare lastSavedAt: DateTime
+  @column()
+  declare mediaKind: string | null
+  @column()
+  declare mediaProvider: string | null
   @column()
   declare ogImage: string | null
   @column.dateTime()
@@ -82,10 +119,42 @@ export class BookmarkSchema extends BaseModel {
   declare tags: any
   @column()
   declare title: string
+  @column.dateTime()
+  declare transcribedAt: DateTime | null
+  @column()
+  declare transcriptionError: string | null
+  @column()
+  declare transcriptionStatus: string
+  @column()
+  declare transcriptionText: string | null
   @column()
   declare type: string
   @column()
   declare url: string
   @column()
   declare urlHash: string
+}
+
+export class SiteCredentialSchema extends BaseModel {
+  static $columns = [
+    'cookieCount',
+    'createdAt',
+    'domain',
+    'encryptedCookies',
+    'id',
+    'updatedAt',
+  ] as const
+  $columns = SiteCredentialSchema.$columns
+  @column()
+  declare cookieCount: number
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+  @column()
+  declare domain: string
+  @column()
+  declare encryptedCookies: string
+  @column({ isPrimary: true })
+  declare id: string
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
 }

--- a/apps/api/tests/functional/bookmarks.spec.ts
+++ b/apps/api/tests/functional/bookmarks.spec.ts
@@ -40,7 +40,7 @@ test.group('POST /bookmarks', (group) => {
   test('stores one client capture for extension saves', async ({ client, assert }) => {
     const response = await client
       .post('/bookmarks')
-      .headers(auth)
+      .headers({ ...auth, host: 'api.local:4567' })
       .json({
         url: 'https://example.com/captured',
         sharedFrom: 'chrome-extension',
@@ -54,6 +54,7 @@ test.group('POST /bookmarks', (group) => {
     assert.equal(body.capture.width, 1280)
     assert.equal(body.capture.height, 720)
     assert.isAbove(body.capture.byteSize, 0)
+    assert.match(body.capture.url, /^http:\/\/api\.local:4567\/captures\/[0-9a-f-]{36}\.png$/)
 
     const capturePath = new URL(body.capture.url).pathname
     const image = await client.get(capturePath)
@@ -92,11 +93,12 @@ test.group('POST /bookmarks', (group) => {
     const media = await client
       .post('/bookmarks')
       .headers(auth)
-      .json({ url: 'https://www.youtube.com/watch?v=abc123' })
+      .json({ url: 'https://www.youtube.com/watch?t=494s&v=0AlrHPbhNdI' })
     media.assertStatus(201)
     assert.equal(media.body().isMedia, true)
     assert.equal(media.body().mediaKind, 'video')
     assert.equal(media.body().mediaProvider, 'youtube')
+    assert.equal(media.body().ogImage, 'https://i.ytimg.com/vi/0AlrHPbhNdI/hqdefault.jpg')
     assert.equal(media.body().transcriptionStatus, 'pending')
     assert.equal(media.body().enrichmentStatus, 'pending')
 
@@ -107,6 +109,24 @@ test.group('POST /bookmarks', (group) => {
     article.assertStatus(201)
     assert.equal(article.body().isMedia, false)
     assert.equal(article.body().transcriptionStatus, 'none')
+  })
+
+  test('uses YouTube thumbnail path instead of storing client capture', async ({
+    client,
+    assert,
+  }) => {
+    const media = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({
+        url: 'https://www.youtube.com/watch?v=thumb123abc',
+        capture: { dataUrl: pngDataUrl, width: 1280, height: 720 },
+      })
+
+    media.assertStatus(201)
+    assert.equal(media.body().mediaProvider, 'youtube')
+    assert.equal(media.body().ogImage, 'https://i.ytimg.com/vi/thumb123abc/hqdefault.jpg')
+    assert.isNull(media.body().capture)
   })
 
   test('transcription failure does not fail enrichment', async ({ assert }) => {
@@ -194,6 +214,24 @@ test.group('GET /bookmarks/:id', (group) => {
     response.assertStatus(200)
     assert.equal(response.body().id, id)
     assert.equal(response.body().url, 'https://example.com/foo')
+  })
+
+  test('derives a YouTube thumbnail when stored ogImage is missing', async ({ client, assert }) => {
+    const created = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://youtube.com/watch?t=494s&v=0AlrHPbhNdI' })
+    const id = created.body().id
+
+    const bookmark = await Bookmark.find(id)
+    assert.exists(bookmark)
+    bookmark!.ogImage = null
+    await bookmark!.save()
+
+    const response = await client.get(`/bookmarks/${id}`).headers(auth)
+
+    response.assertStatus(200)
+    assert.equal(response.body().ogImage, 'https://i.ytimg.com/vi/0AlrHPbhNdI/hqdefault.jpg')
   })
 
   test('returns 404 when bookmark is missing', async ({ client }) => {

--- a/apps/extension/src/lib/siteCredentials.ts
+++ b/apps/extension/src/lib/siteCredentials.ts
@@ -6,13 +6,27 @@ export async function syncCurrentSiteCredentials(
 ): Promise<SiteCredentialMetadata> {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   const siteUrl = getHttpSiteUrl(tab?.url);
+  const cookiesApi = getCookiesApi();
 
-  const cookies = await chrome.cookies.getAll({ url: siteUrl.toString() });
+  const cookies = await cookiesApi.getAll({ url: siteUrl.toString() });
 
   return client.syncSiteCredentials({
     domain: siteUrl.hostname,
     cookies: cookies.map(toSiteCredentialCookie),
   });
+}
+
+function getCookiesApi(): typeof chrome.cookies {
+  const cookiesApi = (chrome as { cookies?: typeof chrome.cookies }).cookies;
+  if (cookiesApi?.getAll) return cookiesApi;
+
+  const permissions = chrome.runtime.getManifest().permissions ?? [];
+  const hasCookiePermission = permissions.includes("cookies");
+  const reason = hasCookiePermission
+    ? "Rechargez l'extension depuis chrome://extensions pour activer la permission cookies."
+    : "La permission cookies est absente du manifest de l'extension.";
+
+  throw new Error(`Impossible de lire les cookies. ${reason}`);
 }
 
 function getHttpSiteUrl(value: string | undefined): URL {

--- a/apps/extension/src/popup/Popup.tsx
+++ b/apps/extension/src/popup/Popup.tsx
@@ -1,5 +1,10 @@
 import { ApiError, StashboxClient } from "@stashbox/api-client";
-import type { Bookmark, ClientCaptureInput, SiteCredentialMetadata } from "@stashbox/shared";
+import {
+  type Bookmark,
+  type ClientCaptureInput,
+  detectMedia,
+  type SiteCredentialMetadata,
+} from "@stashbox/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useSaveFlow } from "../hooks/useSaveFlow.js";
@@ -211,7 +216,10 @@ export function Popup() {
   const save = useCallback(async (): Promise<Bookmark> => {
     if (!client) throw new Error("Not configured");
     const extracted = await extractFromActiveTab();
-    const capture = await captureVisibleViewport();
+    const capture =
+      detectMedia(extracted.url).mediaProvider === "youtube"
+        ? undefined
+        : await captureVisibleViewport();
     try {
       return await client.add({
         url: extracted.url,

--- a/apps/extension/tests/siteCredentials.test.ts
+++ b/apps/extension/tests/siteCredentials.test.ts
@@ -14,6 +14,11 @@ vi.stubGlobal("chrome", {
 describe("syncCurrentSiteCredentials", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("chrome", {
+      tabs: { query },
+      cookies: { getAll },
+      runtime: { getManifest: () => ({ permissions: ["cookies"] }) },
+    });
   });
 
   it("syncs active HTTP site cookies only when called", async () => {
@@ -73,6 +78,19 @@ describe("syncCurrentSiteCredentials", () => {
       "Site credentials require an HTTP or HTTPS page",
     );
     expect(getAll).not.toHaveBeenCalled();
+    expect(syncSiteCredentials).not.toHaveBeenCalled();
+  });
+
+  it("explains when the cookies API is unavailable until extension reload", async () => {
+    vi.stubGlobal("chrome", {
+      tabs: { query },
+      runtime: { getManifest: () => ({ permissions: ["cookies"] }) },
+    });
+    query.mockResolvedValue([{ url: "https://example.com/account" }]);
+
+    await expect(syncCurrentSiteCredentials({ syncSiteCredentials } as never)).rejects.toThrow(
+      "Rechargez l'extension depuis chrome://extensions",
+    );
     expect(syncSiteCredentials).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-browse-page.tsx
@@ -130,8 +130,32 @@ export function BookmarkBrowsePage({
   }, []);
 
   async function handleDeleteBookmark(id: string) {
-    await onDeleteBookmark(id);
-    setVisibleBookmarks((current) => current.filter((bookmark) => bookmark.id !== id));
+    let removedBookmark: Bookmark | undefined;
+    let removedIndex = -1;
+
+    setVisibleBookmarks((current) => {
+      removedIndex = current.findIndex((bookmark) => bookmark.id === id);
+      removedBookmark = removedIndex >= 0 ? current[removedIndex] : undefined;
+      return current.filter((bookmark) => bookmark.id !== id);
+    });
+    setSemanticResults((current) =>
+      current ? current.filter((bookmark) => bookmark.id !== id) : current,
+    );
+
+    try {
+      await onDeleteBookmark(id);
+    } catch {
+      const bookmarkToRestore = removedBookmark;
+      if (bookmarkToRestore) {
+        setVisibleBookmarks((current) => {
+          if (current.some((bookmark) => bookmark.id === id)) return current;
+
+          const restoredBookmarks = [...current];
+          restoredBookmarks.splice(Math.max(removedIndex, 0), 0, bookmarkToRestore);
+          return restoredBookmarks;
+        });
+      }
+    }
   }
 
   async function handleDeleteSiteCredential(id: string) {

--- a/apps/web/src/components/bookmarks/bookmark-card.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-card.tsx
@@ -18,7 +18,7 @@ export function BookmarkCard({ bookmark, onDeleteBookmark }: BookmarkCardProps) 
   const [hasCopiedUrl, setHasCopiedUrl] = useState(false);
   const domain = getDomain(bookmark.url);
   const title = bookmark.title.trim() || domain || bookmark.url;
-  const previewImageUrl = bookmark.capture?.url ?? bookmark.ogImage;
+  const previewImageUrl = getPreviewImageUrl(bookmark);
   const isLoading =
     bookmark.enrichmentStatus === "pending" || bookmark.enrichmentStatus === "enriching";
 
@@ -425,6 +425,14 @@ function getStatusLabel(status: Bookmark["enrichmentStatus"]) {
   if (status === "degraded") return "Dégradé";
   if (status === "failed") return "Échec";
   return "En attente";
+}
+
+function getPreviewImageUrl(bookmark: Bookmark) {
+  if (bookmark.mediaProvider === "youtube") {
+    return bookmark.ogImage ?? bookmark.capture?.url ?? null;
+  }
+
+  return bookmark.capture?.url ?? bookmark.ogImage;
 }
 
 function getStatusClassName(status: Bookmark["enrichmentStatus"]) {

--- a/apps/web/src/server/stashbox.ts
+++ b/apps/web/src/server/stashbox.ts
@@ -68,13 +68,22 @@ export const createStashboxServerOperations = serverOnly((client = getStashboxSe
       client.search(searchBookmarksSchema.parse(params)),
     addBookmark: async (params: AddParams) => client.add(addBookmarkSchema.parse(params)),
     deleteBookmark: async ({ id }: { id: string }) =>
-      client.delete(deleteBookmarkSchema.parse({ id }).id),
+      ignoreNotFound(() => client.delete(deleteBookmarkSchema.parse({ id }).id)),
     listSiteCredentials: async () => client.listSiteCredentials(),
     deleteSiteCredential: async ({ id }: { id: string }) =>
       client.deleteSiteCredential(deleteSiteCredentialSchema.parse({ id }).id),
     listTags: async () => client.tags(),
   };
 });
+
+async function ignoreNotFound(action: () => Promise<void>): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return;
+    throw error;
+  }
+}
 
 function createClient(fetch?: typeof globalThis.fetch): StashboxClient {
   return new StashboxClient({

--- a/apps/web/tests/bookmark-browse-page.test.tsx
+++ b/apps/web/tests/bookmark-browse-page.test.tsx
@@ -817,7 +817,7 @@ describe("BookmarkBrowsePage", () => {
     expect(screen.getByText("0 Bookmarks")).toBeInTheDocument();
   });
 
-  it("disables the delete confirmation while deletion is in flight", async () => {
+  it("removes the Bookmark immediately while deletion is in flight", async () => {
     let finishDelete!: () => void;
     const deleteBookmark = vi.fn(
       () =>
@@ -843,14 +843,41 @@ describe("BookmarkBrowsePage", () => {
 
     fireEvent.click(confirmButton);
 
-    await waitFor(() => expect(confirmButton).toBeDisabled());
-    expect(confirmButton).toHaveTextContent("Suppression...");
-    expect(within(dialog).getByRole("button", { name: "Annuler" })).toBeDisabled();
+    expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("alertdialog", { name: "Supprimer ce bookmark ?" }),
+    ).not.toBeInTheDocument();
 
     finishDelete();
-    await waitFor(() =>
-      expect(screen.queryByRole("article", { name: "Readable systems" })).not.toBeInTheDocument(),
+    await waitFor(() => expect(deleteBookmark).toHaveBeenCalledTimes(1));
+  });
+
+  it("restores the Bookmark when deletion fails", async () => {
+    const deleteBookmark = vi.fn().mockRejectedValue(new Error("API unavailable"));
+    renderPage(
+      <BookmarkBrowsePage
+        bookmarks={[createBookmark({ title: "Readable systems" })]}
+        onSaveBookmark={async () => {}}
+        onDeleteBookmark={deleteBookmark}
+      />,
     );
+
+    fireEvent.click(
+      within(screen.getByRole("article", { name: "Readable systems" })).getByRole("button", {
+        name: "Supprimer Readable systems",
+      }),
+    );
+    fireEvent.click(
+      within(screen.getByRole("alertdialog", { name: "Supprimer ce bookmark ?" })).getByRole(
+        "button",
+        { name: "Supprimer" },
+      ),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("article", { name: "Readable systems" })).toBeInTheDocument(),
+    );
+    expect(deleteBookmark).toHaveBeenCalledWith("00000000-0000-4000-8000-000000000001");
   });
 });
 

--- a/apps/web/tests/bookmark-card.test.tsx
+++ b/apps/web/tests/bookmark-card.test.tsx
@@ -108,6 +108,42 @@ describe("BookmarkCard", () => {
     expect(thumbnail).toHaveClass("scale-[1.18]", "object-center");
   });
 
+  it("prefers client capture over Open Graph for non-YouTube bookmarks", () => {
+    render(
+      <BookmarkCard
+        bookmark={createBookmark({
+          capture: createCapture("https://api.example.com/captures/article.png"),
+          ogImage: "https://example.com/og.png",
+        })}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Aperçu de Readable systems" })).toHaveAttribute(
+      "src",
+      "https://api.example.com/captures/article.png",
+    );
+  });
+
+  it("prefers the YouTube thumbnail over client capture for YouTube bookmarks", () => {
+    render(
+      <BookmarkCard
+        bookmark={createBookmark({
+          type: "youtube",
+          mediaProvider: "youtube",
+          capture: createCapture("https://api.example.com/captures/youtube.png"),
+          ogImage: "https://i.ytimg.com/vi/abc/hqdefault.jpg",
+        })}
+        onDeleteBookmark={async () => {}}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Aperçu de Readable systems" })).toHaveAttribute(
+      "src",
+      "https://i.ytimg.com/vi/abc/hqdefault.jpg",
+    );
+  });
+
   it("shows a domain fallback when no thumbnail is available", () => {
     render(
       <BookmarkCard
@@ -223,5 +259,17 @@ function createBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
     lastSavedAt: "2026-05-06T06:00:00.000Z",
     savedFrom: ["api"],
     ...overrides,
+  };
+}
+
+function createCapture(url: string): NonNullable<Bookmark["capture"]> {
+  return {
+    url,
+    source: "client",
+    mimeType: "image/png",
+    width: 1280,
+    height: 720,
+    byteSize: 123,
+    capturedAt: "2026-05-06T06:00:00.000Z",
   };
 }

--- a/apps/web/tests/stashbox-server-client.test.ts
+++ b/apps/web/tests/stashbox-server-client.test.ts
@@ -147,6 +147,23 @@ describe("Bookmark server functions", () => {
     expect(requests[0]?.init?.method).toBe("DELETE");
   });
 
+  it("treats a missing Bookmark delete as already deleted", async () => {
+    vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
+    vi.stubEnv("STASHBOX_API_KEY", "secret-key");
+    vi.resetModules();
+
+    vi.stubGlobal("fetch", async () =>
+      Response.json({ error: "not_found", message: "Bookmark not found" }, { status: 404 }),
+    );
+
+    const { createStashboxServerOperations } = await import("~/server/stashbox.ts");
+    const operations = createStashboxServerOperations();
+
+    await expect(
+      operations.deleteBookmark({ id: "00000000-0000-4000-8000-000000000001" }),
+    ).resolves.toBeUndefined();
+  });
+
   it("lists Tags through the server-side Stashbox API client", async () => {
     vi.stubEnv("STASHBOX_API_URL", "https://stashbox.example");
     vi.stubEnv("STASHBOX_API_KEY", "secret-key");

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export { detectMedia } from "./detect-media.js";
 export { detectType } from "./detect-type.js";
 export { hashUrl } from "./hash-url.js";
 export { normalizeUrl } from "./normalize-url.js";
+export { getYouTubeThumbnailUrl, getYouTubeVideoId } from "./youtube.js";
 export type {
   ApiError,
   Bookmark,

--- a/packages/shared/src/youtube.ts
+++ b/packages/shared/src/youtube.ts
@@ -1,0 +1,40 @@
+const YOUTUBE_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+export function getYouTubeVideoId(input: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+
+  const host = url.hostname.toLowerCase();
+  if (host === "youtu.be") {
+    return pickValidId(url.pathname.split("/").filter(Boolean)[0]);
+  }
+
+  if (host !== "youtube.com" && !host.endsWith(".youtube.com")) return null;
+
+  if (url.pathname === "/watch") {
+    return pickValidId(url.searchParams.get("v"));
+  }
+
+  const [section, id] = url.pathname.split("/").filter(Boolean);
+  if (section === "shorts" || section === "embed" || section === "live") {
+    return pickValidId(id);
+  }
+
+  return null;
+}
+
+export function getYouTubeThumbnailUrl(input: string): string | null {
+  const videoId = getYouTubeVideoId(input);
+  return videoId ? `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg` : null;
+}
+
+function pickValidId(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return YOUTUBE_ID_PATTERN.test(value) ? value : null;
+}

--- a/packages/shared/tests/youtube.test.ts
+++ b/packages/shared/tests/youtube.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { getYouTubeThumbnailUrl, getYouTubeVideoId } from "../src/youtube.js";
+
+describe("YouTube URL helpers", () => {
+  it.each([
+    ["https://youtube.com/watch?t=494s&v=0AlrHPbhNdI", "0AlrHPbhNdI"],
+    ["https://www.youtube.com/watch?v=0AlrHPbhNdI&t=494s", "0AlrHPbhNdI"],
+    ["https://youtu.be/0AlrHPbhNdI?t=494", "0AlrHPbhNdI"],
+    ["https://youtube.com/shorts/0AlrHPbhNdI", "0AlrHPbhNdI"],
+    ["https://youtube.com/embed/0AlrHPbhNdI", "0AlrHPbhNdI"],
+    ["https://youtube.com/live/0AlrHPbhNdI", "0AlrHPbhNdI"],
+  ])("extracts the video id from %s", (url, expected) => {
+    expect(getYouTubeVideoId(url)).toBe(expected);
+  });
+
+  it("builds the canonical YouTube thumbnail URL", () => {
+    expect(getYouTubeThumbnailUrl("https://youtube.com/watch?v=0AlrHPbhNdI")).toBe(
+      "https://i.ytimg.com/vi/0AlrHPbhNdI/hqdefault.jpg",
+    );
+  });
+
+  it.each([
+    "https://youtube.com.evil.example/watch?v=0AlrHPbhNdI",
+    "https://youtube.com/watch?v=short",
+    "https://example.com/watch?v=0AlrHPbhNdI",
+    "not a url",
+  ])("returns null for non-YouTube video URL %s", (url) => {
+    expect(getYouTubeVideoId(url)).toBeNull();
+    expect(getYouTubeThumbnailUrl(url)).toBeNull();
+  });
+});

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -15,3 +15,8 @@
 - Avoid native selects for polished compact filter menus on macOS; use the app dropdown component so popup styling stays controlled.
 - In shadcn/Radix triggers, parent arbitrary selectors like `[&>span]:line-clamp-1` can override `hidden` on direct child spans; wrap responsive text in a non-span element when compact controls must stay icon-only.
 - When adding Radix primitives in a Vite monorepo, dedupe `react` and `react-dom` in `vite.config.ts` before trusting e2e hydration results.
+- Capture asset URLs should be derived from the actual API request origin, not only `APP_URL`; local self-hosted ports can diverge between `.env` files.
+- For provider-native rich media like YouTube, prefer provider thumbnails over generic page screenshots and skip client capture when possible.
+- Web server functions should treat stale delete `404 not_found` responses as idempotent success when the user intent is "remove from this list".
+- Delete interactions should remove list items optimistically before awaiting server functions, then restore on rejection; otherwise interrupted dev/server calls can leave confirmation dialogs stuck.
+- YouTube thumbnails must be derived from the video id at ingest/serialization time; extension-provided content can skip oEmbed enrichment entirely.


### PR DESCRIPTION
## Summary

Stabilizes the post-merge bookmark capture/media flow, including capture URLs, YouTube thumbnails, delete behavior, and extension cookie sync. Fixes #54, #56, #58.

## Changes

- `apps/api/app/controllers/bookmarks_controller.ts` — normalizes capture URLs from the request origin and derives YouTube thumbnails for new/existing rows.
- `apps/api/app/services/youtube_thumbnail.ts` — adds API-local YouTube thumbnail derivation.
- `apps/api/app/services/fetch_provider.ts` — falls back to derived YouTube thumbnails when oEmbed is unavailable.
- `apps/api/app/jobs/enrich_bookmark_job.ts` — persists metadata thumbnails from meta-only fetches.
- `apps/api/tests/functional/bookmarks.spec.ts` — covers capture origin, YouTube capture skipping, and legacy thumbnail fallback.
- `apps/extension/src/popup/Popup.tsx` — skips client screenshots for YouTube saves.
- `apps/extension/src/lib/siteCredentials.ts` — hardens cookie API availability errors.
- `apps/web/src/components/bookmarks/bookmark-browse-page.tsx` — removes deleted bookmarks optimistically with rollback.
- `apps/web/src/components/bookmarks/bookmark-card.tsx` — prefers YouTube thumbnails over captures.
- `packages/shared/src/youtube.ts` — adds shared YouTube URL parsing helpers.
- …and 9 more

## Test plan

- [x] CI passes
- [x] Manual smoke test: save a YouTube URL and a normal page, then verify thumbnail/capture and delete behavior in the browser.