### PR TITLE
feat: Add Server Capture for URL-only saves

### DIFF
--- a/apps/api/app/controllers/bookmarks_controller.ts
+++ b/apps/api/app/controllers/bookmarks_controller.ts
@@ -8,6 +8,7 @@ import vine from '@vinejs/vine'
 import { DateTime } from 'luxon'
 
 import Bookmark from '#models/bookmark'
+import captureQueue from '#services/capture_queue'
 import { storeClientCapture, type StoredCapture } from '#services/capture_storage'
 import enrichmentQueue from '#services/enrichment_queue'
 import transcriptionQueue from '#services/transcription_queue'
@@ -141,7 +142,11 @@ export default class BookmarksController {
       savedFrom: payload.sharedFrom ? [payload.sharedFrom] : [],
     })
 
+    const shouldRunServerCapture = !capture && media.mediaProvider !== 'youtube'
     await Promise.all([
+      shouldRunServerCapture
+        ? captureQueue.dispatch(bookmark.id, captureBaseUrl)
+        : Promise.resolve(),
       enrichmentQueue.dispatch(bookmark.id, payload.content),
       media.isMedia ? transcriptionQueue.dispatch(bookmark.id) : Promise.resolve(),
     ])

--- a/apps/api/app/jobs/capture_bookmark_job.ts
+++ b/apps/api/app/jobs/capture_bookmark_job.ts
@@ -1,0 +1,35 @@
+import app from '@adonisjs/core/services/app'
+import { DateTime } from 'luxon'
+
+import Bookmark from '#models/bookmark'
+import { storeServerCapture } from '#services/capture_storage'
+import ServerCaptureProvider from '#services/server_capture_provider'
+import env from '#start/env'
+
+export default class CaptureBookmarkJob {
+  static async handle(bookmarkId: string, baseUrl?: string): Promise<void> {
+    const bookmark = await Bookmark.find(bookmarkId)
+    if (!bookmark || bookmark.capturePath || bookmark.captureUrl) return
+    if (bookmark.mediaProvider === 'youtube') return
+
+    try {
+      const provider = await app.container.make(ServerCaptureProvider)
+      const capture = await provider.capture(bookmark.url)
+      const stored = await storeServerCapture(bookmark.id, capture, baseUrl)
+
+      bookmark.capturePath = stored.path
+      bookmark.captureUrl = stored.url
+      bookmark.captureSource = stored.source
+      bookmark.captureMimeType = stored.mimeType
+      bookmark.captureWidth = stored.width
+      bookmark.captureHeight = stored.height
+      bookmark.captureByteSize = stored.byteSize
+      bookmark.capturedAt = DateTime.fromISO(stored.capturedAt)
+      await bookmark.save()
+    } catch (error) {
+      if (env.get('NODE_ENV') !== 'test') {
+        console.error('[capture] server capture failed', error)
+      }
+    }
+  }
+}

--- a/apps/api/app/models/bookmark.ts
+++ b/apps/api/app/models/bookmark.ts
@@ -48,7 +48,7 @@ export default class Bookmark extends BaseModel {
   declare captureUrl: string | null
 
   @column()
-  declare captureSource: 'client' | null
+  declare captureSource: 'client' | 'server' | null
 
   @column()
   declare captureMimeType: 'image/png' | null

--- a/apps/api/app/services/capture_queue.ts
+++ b/apps/api/app/services/capture_queue.ts
@@ -1,42 +1,42 @@
 import type { Queue, Worker } from 'bullmq'
 
-import EnrichBookmarkJob from '#jobs/enrich_bookmark_job'
+import CaptureBookmarkJob from '#jobs/capture_bookmark_job'
 import env from '#start/env'
 
-const QUEUE_NAME = 'enrichment'
-const JOB_NAME = 'enrich-bookmark'
+const QUEUE_NAME = 'capture'
+const JOB_NAME = 'capture-bookmark'
 
-interface EnrichJobData {
+interface CaptureJobData {
   bookmarkId: string
-  content?: string
+  baseUrl?: string
 }
 
-class EnrichmentQueueService {
-  private bullQueue: Queue<EnrichJobData> | null = null
-  private worker: Worker<EnrichJobData> | null = null
-  private inProcessJobs: EnrichJobData[] = []
+class CaptureQueueService {
+  private bullQueue: Queue<CaptureJobData> | null = null
+  private worker: Worker<CaptureJobData> | null = null
+  private inProcessJobs: CaptureJobData[] = []
 
   private get useInProcess(): boolean {
     return env.get('NODE_ENV') === 'test'
   }
 
-  private async getBullQueue(): Promise<Queue<EnrichJobData>> {
+  private async getBullQueue(): Promise<Queue<CaptureJobData>> {
     if (this.bullQueue) return this.bullQueue
     const { Queue: BullQueue } = await import('bullmq')
-    this.bullQueue = new BullQueue<EnrichJobData>(QUEUE_NAME, {
+    this.bullQueue = new BullQueue<CaptureJobData>(QUEUE_NAME, {
       connection: { url: env.get('REDIS_URL') },
     })
     return this.bullQueue
   }
 
-  async dispatch(bookmarkId: string, content?: string): Promise<void> {
+  async dispatch(bookmarkId: string, baseUrl?: string): Promise<void> {
     if (this.useInProcess) {
-      this.inProcessJobs.push({ bookmarkId, content })
+      this.inProcessJobs.push({ bookmarkId, baseUrl })
       return
     }
 
     const queue = await this.getBullQueue()
-    await queue.add(JOB_NAME, { bookmarkId, content })
+    await queue.add(JOB_NAME, { bookmarkId, baseUrl })
   }
 
   async flush(): Promise<void> {
@@ -44,20 +44,20 @@ class EnrichmentQueueService {
     this.inProcessJobs = []
     await Promise.all(
       pending.map((job) =>
-        EnrichBookmarkJob.handle(job.bookmarkId, job.content).catch((err) => {
-          console.error('[enrichment in-process] job failed', err)
+        CaptureBookmarkJob.handle(job.bookmarkId, job.baseUrl).catch((err) => {
+          console.error('[capture in-process] job failed', err)
         })
       )
     )
   }
 
-  async startWorker(): Promise<Worker<EnrichJobData>> {
+  async startWorker(): Promise<Worker<CaptureJobData>> {
     if (this.worker) return this.worker
     const { Worker: BullWorker } = await import('bullmq')
-    this.worker = new BullWorker<EnrichJobData>(
+    this.worker = new BullWorker<CaptureJobData>(
       QUEUE_NAME,
       async (job) => {
-        await EnrichBookmarkJob.handle(job.data.bookmarkId, job.data.content)
+        await CaptureBookmarkJob.handle(job.data.bookmarkId, job.data.baseUrl)
       },
       { connection: { url: env.get('REDIS_URL') } }
     )
@@ -72,5 +72,5 @@ class EnrichmentQueueService {
   }
 }
 
-const enrichmentQueue = new EnrichmentQueueService()
-export default enrichmentQueue
+const captureQueue = new CaptureQueueService()
+export default captureQueue

--- a/apps/api/app/services/capture_storage.ts
+++ b/apps/api/app/services/capture_storage.ts
@@ -21,6 +21,49 @@ export async function storeClientCapture(
   baseUrl = appUrl
 ): Promise<StoredCapture> {
   const buffer = decodePngDataUrl(capture.dataUrl)
+  return storePngCapture(
+    bookmarkId,
+    buffer,
+    {
+      source: 'client',
+      width: capture.width ?? null,
+      height: capture.height ?? null,
+    },
+    baseUrl
+  )
+}
+
+export async function storeServerCapture(
+  bookmarkId: string,
+  capture: { buffer: Buffer; width?: number | null; height?: number | null },
+  baseUrl = appUrl
+): Promise<StoredCapture> {
+  if (!isPng(capture.buffer)) {
+    throw new InvalidCaptureError('Capture data is not a PNG image')
+  }
+
+  return storePngCapture(
+    bookmarkId,
+    capture.buffer,
+    {
+      source: 'server',
+      width: capture.width ?? null,
+      height: capture.height ?? null,
+    },
+    baseUrl
+  )
+}
+
+async function storePngCapture(
+  bookmarkId: string,
+  buffer: Buffer,
+  metadata: {
+    source: Capture['source']
+    width: number | null
+    height: number | null
+  },
+  baseUrl: string
+): Promise<StoredCapture> {
   const directory = app.makePath('tmp', 'captures')
   const filename = `${bookmarkId}.png`
   const path = join(directory, filename)
@@ -32,10 +75,10 @@ export async function storeClientCapture(
   return {
     path,
     url: `${baseUrl.replace(/\/$/, '')}/captures/${filename}`,
-    source: 'client',
+    source: metadata.source,
     mimeType: 'image/png',
-    width: capture.width ?? null,
-    height: capture.height ?? null,
+    width: metadata.width,
+    height: metadata.height,
     byteSize: buffer.byteLength,
     capturedAt: capturedAt.toISO() ?? capturedAt.toString(),
   }

--- a/apps/api/app/services/server_capture_provider.ts
+++ b/apps/api/app/services/server_capture_provider.ts
@@ -1,0 +1,43 @@
+export interface ServerCaptureResult {
+  buffer: Buffer
+  width: number
+  height: number
+}
+
+const VIEWPORT = { width: 1280, height: 720 } as const
+const NAVIGATION_TIMEOUT_MS = 15_000
+const SETTLE_TIMEOUT_MS = 5_000
+
+export default class ServerCaptureProvider {
+  async capture(url: string): Promise<ServerCaptureResult> {
+    const { chromium } = await import('playwright')
+    const browser = await chromium.launch({ headless: true })
+
+    try {
+      const page = await browser.newPage({
+        viewport: VIEWPORT,
+        deviceScaleFactor: 1,
+      })
+
+      await page.goto(url, {
+        waitUntil: 'domcontentloaded',
+        timeout: NAVIGATION_TIMEOUT_MS,
+      })
+      await page.waitForLoadState('networkidle', { timeout: SETTLE_TIMEOUT_MS }).catch(() => {})
+
+      const buffer = await page.screenshot({
+        type: 'png',
+        fullPage: false,
+        animations: 'disabled',
+      })
+
+      return {
+        buffer,
+        width: VIEWPORT.width,
+        height: VIEWPORT.height,
+      }
+    } finally {
+      await browser.close()
+    }
+  }
+}

--- a/apps/api/app/services/transcription_queue.ts
+++ b/apps/api/app/services/transcription_queue.ts
@@ -13,7 +13,7 @@ interface TranscriptionJobData {
 class TranscriptionQueueService {
   private bullQueue: Queue<TranscriptionJobData> | null = null
   private worker: Worker<TranscriptionJobData> | null = null
-  private inFlight: Promise<void>[] = []
+  private inProcessJobs: TranscriptionJobData[] = []
 
   private get useInProcess(): boolean {
     return env.get('NODE_ENV') === 'test'
@@ -30,10 +30,7 @@ class TranscriptionQueueService {
 
   async dispatch(bookmarkId: string): Promise<void> {
     if (this.useInProcess) {
-      const promise = TranscribeBookmarkJob.handle(bookmarkId).catch((err) => {
-        console.error('[transcription in-process] job failed', err)
-      })
-      this.inFlight.push(promise)
+      this.inProcessJobs.push({ bookmarkId })
       return
     }
 
@@ -42,9 +39,15 @@ class TranscriptionQueueService {
   }
 
   async flush(): Promise<void> {
-    const pending = this.inFlight
-    this.inFlight = []
-    await Promise.all(pending)
+    const pending = this.inProcessJobs
+    this.inProcessJobs = []
+    await Promise.all(
+      pending.map((job) =>
+        TranscribeBookmarkJob.handle(job.bookmarkId).catch((err) => {
+          console.error('[transcription in-process] job failed', err)
+        })
+      )
+    )
   }
 
   async startWorker(): Promise<Worker<TranscriptionJobData>> {

--- a/apps/api/commands/import_csv.ts
+++ b/apps/api/commands/import_csv.ts
@@ -3,7 +3,7 @@ import { createReadStream } from 'node:fs'
 
 import { args, BaseCommand } from '@adonisjs/core/ace'
 import type { CommandOptions } from '@adonisjs/core/types/ace'
-import { hashUrl, normalizeUrl } from '@stashbox/shared'
+import { detectMedia, hashUrl, normalizeUrl } from '@stashbox/shared'
 import { parse as parseCsv } from 'csv-parse'
 import { DateTime } from 'luxon'
 
@@ -28,7 +28,9 @@ export default class ImportCsv extends BaseCommand {
 
   async run() {
     const { default: Bookmark } = await import('#models/bookmark')
+    const { default: captureQueue } = await import('#services/capture_queue')
     const { default: enrichmentQueue } = await import('#services/enrichment_queue')
+    const { getYouTubeThumbnailUrl } = await import('#services/youtube_thumbnail')
 
     let total = 0
     let inserted = 0
@@ -78,6 +80,7 @@ export default class ImportCsv extends BaseCommand {
         if (dt.isValid) savedAt = dt
       }
 
+      const media = detectMedia(normalized)
       const bookmark = await Bookmark.create({
         id: randomUUID(),
         url: normalized,
@@ -86,20 +89,30 @@ export default class ImportCsv extends BaseCommand {
         title: raw.title ?? '',
         description: raw.description ?? '',
         tags,
-        ogImage: null,
+        ogImage: media.mediaProvider === 'youtube' ? getYouTubeThumbnailUrl(normalized) : null,
         embedData: null,
+        isMedia: media.isMedia,
+        mediaKind: media.mediaKind,
+        mediaProvider: media.mediaProvider,
         enrichmentStatus: 'pending',
         enrichmentError: null,
         enrichmentFailureReason: null,
         enrichmentAttempts: 0,
         enrichedAt: null,
         embeddingSourceText: null,
+        transcriptionStatus: media.isMedia ? 'pending' : 'none',
+        transcriptionError: null,
+        transcriptionText: null,
+        transcribedAt: null,
         savedCount: 1,
         savedFrom: ['import-csv'],
         ...(savedAt ? { savedAt, lastSavedAt: savedAt } : {}),
       })
 
-      await enrichmentQueue.dispatch(bookmark.id)
+      await Promise.all([
+        media.mediaProvider === 'youtube' ? Promise.resolve() : captureQueue.dispatch(bookmark.id),
+        enrichmentQueue.dispatch(bookmark.id),
+      ])
       inserted++
     }
 
@@ -107,6 +120,6 @@ export default class ImportCsv extends BaseCommand {
       `Import summary — total: ${total}, inserted: ${inserted}, skipped: ${skipped}, failed: ${failed}`
     )
 
-    await enrichmentQueue.shutdown()
+    await Promise.all([captureQueue.shutdown(), enrichmentQueue.shutdown()])
   }
 }

--- a/apps/api/commands/queue_listen.ts
+++ b/apps/api/commands/queue_listen.ts
@@ -3,7 +3,7 @@ import type { CommandOptions } from '@adonisjs/core/types/ace'
 
 export default class QueueListen extends BaseCommand {
   static commandName = 'queue:listen'
-  static description = 'Start the BullMQ worker processes for enrichment and transcription'
+  static description = 'Start the BullMQ worker processes'
 
   static options: CommandOptions = {
     startApp: true,
@@ -11,14 +11,23 @@ export default class QueueListen extends BaseCommand {
   }
 
   async run() {
+    const { default: captureQueue } = await import('#services/capture_queue')
     const { default: enrichmentQueue } = await import('#services/enrichment_queue')
     const { default: transcriptionQueue } = await import('#services/transcription_queue')
-    const [enrichmentWorker, transcriptionWorker] = await Promise.all([
+    const [captureWorker, enrichmentWorker, transcriptionWorker] = await Promise.all([
+      captureQueue.startWorker(),
       enrichmentQueue.startWorker(),
       transcriptionQueue.startWorker(),
     ])
 
-    this.logger.info('Enrichment and transcription workers started')
+    this.logger.info('Capture, enrichment and transcription workers started')
+
+    captureWorker.on('completed', (job) => {
+      this.logger.info(`capture job ${job.id} completed`)
+    })
+    captureWorker.on('failed', (job, err) => {
+      this.logger.error(`capture job ${job?.id} failed: ${err.message}`)
+    })
 
     enrichmentWorker.on('completed', (job) => {
       this.logger.info(`enrichment job ${job.id} completed`)
@@ -36,7 +45,11 @@ export default class QueueListen extends BaseCommand {
 
     this.app.terminating(async () => {
       this.logger.info('shutting down queue workers...')
-      await Promise.all([enrichmentQueue.shutdown(), transcriptionQueue.shutdown()])
+      await Promise.all([
+        captureQueue.shutdown(),
+        enrichmentQueue.shutdown(),
+        transcriptionQueue.shutdown(),
+      ])
     })
   }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -77,6 +77,7 @@
     "luxon": "^3.7.2",
     "pg": "^8.13.1",
     "pg-query-stream": "^4.14.0",
+    "playwright": "^1.59.1",
     "reflect-metadata": "^0.2.2",
     "zod": "^3.25.76"
   },

--- a/apps/api/scripts/dev.mjs
+++ b/apps/api/scripts/dev.mjs
@@ -14,7 +14,7 @@ const env = {
 }
 
 start('api', ['ace', 'serve', '--hmr'])
-start('worker', ['ace', 'queue:listen'])
+start('worker', ['--watch', '--watch-preserve-output', 'ace', 'queue:listen'])
 
 for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
   process.on(signal, () => shutdown(signal))

--- a/apps/api/tests/functional/bookmarks.spec.ts
+++ b/apps/api/tests/functional/bookmarks.spec.ts
@@ -1,10 +1,13 @@
 import { randomUUID } from 'node:crypto'
 
+import app from '@adonisjs/core/services/app'
 import { test } from '@japa/runner'
 import { hashUrl, normalizeUrl } from '@stashbox/shared'
 
 import TranscribeBookmarkJob from '#jobs/transcribe_bookmark_job'
 import Bookmark from '#models/bookmark'
+import captureQueue from '#services/capture_queue'
+import ServerCaptureProvider from '#services/server_capture_provider'
 import { authHeader } from '#tests/helpers/api_key'
 
 const pngDataUrl =
@@ -14,6 +17,9 @@ test.group('POST /bookmarks', (group) => {
   let auth: { Authorization: string }
   group.each.setup(async () => {
     auth = await authHeader()
+  })
+  group.each.teardown(() => {
+    app.container.restoreAll()
   })
 
   test('creates a bookmark from a URL and returns 201', async ({ client, assert }) => {
@@ -35,6 +41,82 @@ test.group('POST /bookmarks', (group) => {
     assert.equal(body.isMedia, false)
     assert.equal(body.transcriptionStatus, 'none')
     assert.equal(body.savedCount, 1)
+  })
+
+  test('captures URL-only non-YouTube bookmarks in the server worker', async ({
+    client,
+    assert,
+  }) => {
+    let capturedUrl = ''
+    app.container.swap(
+      ServerCaptureProvider,
+      () =>
+        ({
+          capture: async (url: string) => {
+            capturedUrl = url
+            return {
+              buffer: Buffer.from(pngDataUrl.split(',')[1], 'base64'),
+              width: 1280,
+              height: 720,
+            }
+          },
+        }) as unknown as ServerCaptureProvider
+    )
+
+    const created = await client
+      .post('/bookmarks')
+      .headers({ ...auth, host: 'api.local:4567' })
+      .json({ url: 'https://example.com/server-capture' })
+
+    created.assertStatus(201)
+    assert.isNull(created.body().capture)
+
+    await captureQueue.flush()
+
+    const after = await client
+      .get(`/bookmarks/${created.body().id}`)
+      .headers({ ...auth, host: 'api.local:4567' })
+    after.assertStatus(200)
+
+    const capture = after.body().capture
+    assert.equal(capturedUrl, 'https://example.com/server-capture')
+    assert.equal(capture.source, 'server')
+    assert.equal(capture.mimeType, 'image/png')
+    assert.equal(capture.width, 1280)
+    assert.equal(capture.height, 720)
+    assert.isAbove(capture.byteSize, 0)
+    assert.match(capture.url, /^http:\/\/api\.local:4567\/captures\/[0-9a-f-]{36}\.png$/)
+
+    const image = await client.get(new URL(capture.url).pathname)
+    image.assertStatus(200)
+    assert.include(String(image.header('content-type')), 'image/png')
+  })
+
+  test('keeps capture failures isolated from enrichment state', async ({ client, assert }) => {
+    app.container.swap(
+      ServerCaptureProvider,
+      () =>
+        ({
+          capture: async () => {
+            throw new Error('browser unavailable')
+          },
+        }) as unknown as ServerCaptureProvider
+    )
+
+    const created = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://example.com/capture-fails' })
+    created.assertStatus(201)
+
+    await captureQueue.flush()
+
+    const after = await client.get(`/bookmarks/${created.body().id}`).headers(auth)
+    after.assertStatus(200)
+    assert.isNull(after.body().capture)
+    assert.equal(after.body().enrichmentStatus, 'pending')
+    assert.isNull(after.body().enrichmentError)
+    assert.isNull(after.body().enrichmentFailureReason)
   })
 
   test('stores one client capture for extension saves', async ({ client, assert }) => {
@@ -86,6 +168,46 @@ test.group('POST /bookmarks', (group) => {
     assert.equal(second.body().capture.height, 100)
   })
 
+  test('does not enqueue server capture on dedupe collisions', async ({ client, assert }) => {
+    const capturedUrls: string[] = []
+    app.container.swap(
+      ServerCaptureProvider,
+      () =>
+        ({
+          capture: async (url: string) => {
+            capturedUrls.push(url)
+            return {
+              buffer: Buffer.from(pngDataUrl.split(',')[1], 'base64'),
+              width: 1280,
+              height: 720,
+            }
+          },
+        }) as unknown as ServerCaptureProvider
+    )
+
+    const first = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({
+        url: 'https://example.com/dedupe-server-capture?utm_source=one',
+        capture: { dataUrl: pngDataUrl, width: 100, height: 100 },
+      })
+    first.assertStatus(201)
+
+    const second = await client
+      .post('/bookmarks')
+      .headers(auth)
+      .json({ url: 'https://www.example.com/dedupe-server-capture/' })
+    second.assertStatus(409)
+
+    await captureQueue.flush()
+
+    assert.deepEqual(capturedUrls, [])
+    assert.equal(second.body().id, first.body().id)
+    assert.equal(second.body().capture.source, 'client')
+    assert.equal(second.body().capture.width, 100)
+  })
+
   test('marks allowlisted media for transcription without blocking save', async ({
     client,
     assert,
@@ -126,6 +248,9 @@ test.group('POST /bookmarks', (group) => {
     media.assertStatus(201)
     assert.equal(media.body().mediaProvider, 'youtube')
     assert.equal(media.body().ogImage, 'https://i.ytimg.com/vi/thumb123abc/hqdefault.jpg')
+    assert.isNull(media.body().capture)
+
+    await captureQueue.flush()
     assert.isNull(media.body().capture)
   })
 

--- a/apps/api/tests/functional/csv_commands.spec.ts
+++ b/apps/api/tests/functional/csv_commands.spec.ts
@@ -8,14 +8,19 @@ import { test } from '@japa/runner'
 import nock from 'nock'
 
 import Bookmark from '#models/bookmark'
+import captureQueue from '#services/capture_queue'
 import EmbeddingProvider from '#services/embedding_provider'
 import enrichmentQueue from '#services/enrichment_queue'
 import LlmProvider from '#services/llm_provider'
+import ServerCaptureProvider from '#services/server_capture_provider'
 import { mockEmbeddingReturning } from '#tests/helpers/mock_embedding'
 import { mockModelReturning } from '#tests/helpers/mock_llm'
 
 import ExportCsv from '../../commands/export_csv.js'
 import ImportCsv from '../../commands/import_csv.js'
+
+const pngDataUrl =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
 
 async function tmpFile(name: string, content = ''): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'stashbox-csv-'))
@@ -87,6 +92,40 @@ test.group('ace import:csv', (group) => {
     const row = await Bookmark.findByOrFail('url', 'https://example.com/a')
     assert.exists(row.id)
     assert.match(logsOf(command), /inserted[^\n]*1/i)
+  })
+
+  test('captures imported URL-only rows in the server worker', async ({ assert }) => {
+    let capturedUrl = ''
+    app.container.swap(
+      ServerCaptureProvider,
+      () =>
+        ({
+          capture: async (url: string) => {
+            capturedUrl = url
+            return {
+              buffer: Buffer.from(pngDataUrl.split(',')[1], 'base64'),
+              width: 1280,
+              height: 720,
+            }
+          },
+        }) as unknown as ServerCaptureProvider
+    )
+
+    const path = await tmpFile('capture.csv', 'url,title\nhttps://example.com/import-capture,A\n')
+    const command = await ace.create(ImportCsv, [path])
+    command.ui.switchMode('raw')
+    await command.exec()
+
+    await captureQueue.flush()
+    await enrichmentQueue.flush()
+
+    const row = await Bookmark.findByOrFail('url', 'https://example.com/import-capture')
+    assert.equal(capturedUrl, 'https://example.com/import-capture')
+    assert.equal(row.captureSource, 'server')
+    assert.equal(row.captureMimeType, 'image/png')
+    assert.equal(row.captureWidth, 1280)
+    assert.equal(row.captureHeight, 720)
+    assert.isAbove(row.captureByteSize ?? 0, 0)
   })
 
   test('skips duplicate urls', async ({ assert }) => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,7 +3,6 @@ export { detectMedia } from "./detect-media.js";
 export { detectType } from "./detect-type.js";
 export { hashUrl } from "./hash-url.js";
 export { normalizeUrl } from "./normalize-url.js";
-export { getYouTubeThumbnailUrl, getYouTubeVideoId } from "./youtube.js";
 export type {
   ApiError,
   Bookmark,
@@ -42,3 +41,4 @@ export {
   SyncSiteCredentialsInputSchema,
   TranscriptionStatusSchema,
 } from "./schemas.js";
+export { getYouTubeThumbnailUrl, getYouTubeVideoId } from "./youtube.js";

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -60,7 +60,7 @@ export type ClientCaptureInput = z.infer<typeof ClientCaptureInputSchema>;
 
 export const CaptureSchema = z.object({
   url: z.string().url(),
-  source: z.enum(["client"]),
+  source: z.enum(["client", "server"]),
   mimeType: z.literal("image/png"),
   width: z.number().int().positive().nullable(),
   height: z.number().int().positive().nullable(),

--- a/packages/shared/tests/schemas.test.ts
+++ b/packages/shared/tests/schemas.test.ts
@@ -174,10 +174,10 @@ describe("BookmarkSchema", () => {
     expect(() => BookmarkSchema.parse(valid)).not.toThrow();
   });
 
-  it("accepts capture metadata on a bookmark", () => {
+  it.each(["client", "server"] as const)("accepts %s capture metadata on a bookmark", (source) => {
     const capture = CaptureSchema.parse({
       url: "http://localhost:3334/captures/550e8400-e29b-41d4-a716-446655440000.png",
-      source: "client",
+      source,
       mimeType: "image/png",
       width: 1200,
       height: 800,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       pg-query-stream:
         specifier: ^4.14.0
         version: 4.14.0(pg@8.20.0)
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -20,3 +20,4 @@
 - Web server functions should treat stale delete `404 not_found` responses as idempotent success when the user intent is "remove from this list".
 - Delete interactions should remove list items optimistically before awaiting server functions, then restore on rejection; otherwise interrupted dev/server calls can leave confirmation dialogs stuck.
 - YouTube thumbnails must be derived from the video id at ingest/serialization time; extension-provided content can skip oEmbed enrichment entirely.
+- When adding a new long-lived queue worker, update the dev runner restart path too; API HMR invalidates HTTP modules, but an existing `ace queue:listen` process keeps its old imports until restarted.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,34 @@
+# Issue 55 - Server Capture for URL-only Saves
+
+## Plan
+
+- [x] Read GitHub issue #55 and create draft PR linked with `Closes #55`.
+- [x] RED 1: API functional test proves URL-only bookmark save returns immediately with no capture, then async server capture fills capture metadata after queue flush.
+- [x] GREEN 1: Add server capture queue/job and wire URL-only saves to dispatch without blocking response.
+- [x] RED 2: worker failure leaves bookmark/enrichment healthy and capture empty.
+- [x] GREEN 2: isolate capture failures and keep them non-blocking.
+- [x] RED 3: dedupe/conflict does not enqueue or replace an existing capture.
+- [x] GREEN 3: preserve existing dedupe behavior.
+- [x] RED/GREEN: import CSV URL-only rows also enqueue Server Capture.
+- [x] Refactor: keep Playwright rendering behind a small provider interface and reuse capture storage serialization.
+- [x] Verify API tests, typecheck, focused lint/prettier, and a local browser smoke test.
+
+## Review
+
+- Server Capture now uses a dedicated BullMQ queue and local Playwright provider.
+- URL-only API saves enqueue capture without blocking the 201 response; YouTube keeps thumbnail behavior.
+- CSV import also dispatches capture for URL-only non-YouTube rows.
+- Capture failures are isolated from enrichment state.
+- Targeted lint/prettier, package typechecks, API test suite, shared/api-client tests, and Playwright smoke passed.
+
+## Scope
+
+- Apps/packages: `apps/api` primarily; `apps/web` only if display ordering needs adjustment.
+- Public behavior: `/bookmarks` response remains fast; capture arrives asynchronously through the worker.
+- Out of scope: authenticated server capture with saved cookies (#57) and Groq transcription (#59).
+
+---
+
 # Parallel Implementation: Issues #54, #56, #58
 
 ## Plan

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -20,6 +20,7 @@
 - CSV import also dispatches capture for URL-only non-YouTube rows.
 - Capture failures are isolated from enrichment state.
 - Targeted lint/prettier, package typechecks, API test suite, shared/api-client tests, and Playwright smoke passed.
+- Follow-up diagnosis: the current dev worker process was stale after adding `captureQueue`; `apps/api/scripts/dev.mjs` now runs `queue:listen` under Node watch mode so future worker code changes restart the worker.
 
 ## Scope
 


### PR DESCRIPTION
Closes #55

## Summary

- Add an async Server Capture queue/job backed by local Playwright.
- Store normalized PNG captures with `source: server` and reuse existing `/captures/:file` serving.
- Wire URL-only API saves and CSV imports to enqueue captures without blocking save responses.
- Keep YouTube on thumbnail-only behavior and isolate capture failures from enrichment.
- Run the API worker under Node watch mode in dev so new/changed queues restart with code changes.

## Test plan

- [x] `pnpm --filter @stashbox/api test`
- [x] `pnpm --filter @stashbox/api typecheck`
- [x] `pnpm --filter @stashbox/shared test`
- [x] `pnpm --filter @stashbox/shared typecheck`
- [x] `pnpm --filter @stashbox/api-client test`
- [x] `pnpm --filter @stashbox/api-client typecheck`
- [x] `pnpm --filter @stashbox/web typecheck`
- [x] targeted eslint/prettier on changed files
- [x] Playwright headless PNG smoke test
- [x] Web add flow smoke via Playwright against `http://localhost:5173/`
- [x] pre-commit hook: `turbo run typecheck` + `turbo run test`
- [x] CI passes