### PR TITLE
feat: Use Site credentials for Server Capture

### DIFF
--- a/apps/api/app/jobs/capture_bookmark_job.ts
+++ b/apps/api/app/jobs/capture_bookmark_job.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 
 import Bookmark from '#models/bookmark'
 import { storeServerCapture } from '#services/capture_storage'
+import { loadServerCaptureCookies } from '#services/server_capture_credentials'
 import ServerCaptureProvider from '#services/server_capture_provider'
 import env from '#start/env'
 
@@ -14,7 +15,8 @@ export default class CaptureBookmarkJob {
 
     try {
       const provider = await app.container.make(ServerCaptureProvider)
-      const capture = await provider.capture(bookmark.url)
+      const cookies = await loadServerCaptureCookies(bookmark.url)
+      const capture = await provider.capture(bookmark.url, { cookies })
       const stored = await storeServerCapture(bookmark.id, capture, baseUrl)
 
       bookmark.capturePath = stored.path

--- a/apps/api/app/services/server_capture_credentials.ts
+++ b/apps/api/app/services/server_capture_credentials.ts
@@ -1,0 +1,66 @@
+import type { SiteCredentialCookie } from '@stashbox/shared'
+
+import SiteCredential from '#models/site_credential'
+import type { ServerCaptureCookie } from '#services/server_capture_provider'
+import { decryptSiteCredentialCookies } from '#services/site_credentials_encryption'
+
+export async function loadServerCaptureCookies(url: string): Promise<ServerCaptureCookie[]> {
+  const targetUrl = new URL(url)
+  const host = targetUrl.hostname.toLowerCase()
+  const credentials = (
+    await SiteCredential.query().whereIn('domain', credentialDomainCandidates(host))
+  ).sort((a, b) => b.domain.length - a.domain.length)
+
+  if (!credentials.length) return []
+
+  return credentials.flatMap((siteCredential) => {
+    let cookies: SiteCredentialCookie[]
+    try {
+      cookies = decryptSiteCredentialCookies(siteCredential.domain, siteCredential.encryptedCookies)
+    } catch {
+      return []
+    }
+
+    return cookies
+      .filter((cookie) => cookieAppliesToUrl(cookie, targetUrl))
+      .map(toServerCaptureCookie)
+  })
+}
+
+function credentialDomainCandidates(host: string): string[] {
+  const parts = host.split('.').filter(Boolean)
+
+  return parts.map((_, index) => parts.slice(index).join('.'))
+}
+
+function cookieAppliesToUrl(cookie: SiteCredentialCookie, targetUrl: URL): boolean {
+  const host = targetUrl.hostname.toLowerCase()
+  const cookieDomain = cookie.domain.replace(/^\./, '').toLowerCase()
+
+  if (cookie.secure && targetUrl.protocol !== 'https:') return false
+  if (cookie.hostOnly && host !== cookieDomain) return false
+  if (!cookie.hostOnly && host !== cookieDomain && !host.endsWith(`.${cookieDomain}`)) return false
+
+  return targetUrl.pathname.startsWith(cookie.path || '/')
+}
+
+function toServerCaptureCookie(cookie: SiteCredentialCookie): ServerCaptureCookie {
+  return {
+    name: cookie.name,
+    value: cookie.value,
+    domain: cookie.domain,
+    path: cookie.path || '/',
+    secure: cookie.secure,
+    httpOnly: cookie.httpOnly,
+    ...(cookie.session || !cookie.expirationDate ? {} : { expires: cookie.expirationDate }),
+    ...sameSiteCookieOption(cookie),
+  }
+}
+
+function sameSiteCookieOption(cookie: SiteCredentialCookie): Pick<ServerCaptureCookie, 'sameSite'> {
+  if (cookie.sameSite === 'strict') return { sameSite: 'Strict' }
+  if (cookie.sameSite === 'lax') return { sameSite: 'Lax' }
+  if (cookie.sameSite === 'no_restriction') return { sameSite: 'None' }
+
+  return {}
+}

--- a/apps/api/app/services/server_capture_provider.ts
+++ b/apps/api/app/services/server_capture_provider.ts
@@ -4,37 +4,62 @@ export interface ServerCaptureResult {
   height: number
 }
 
+export interface ServerCaptureCookie {
+  name: string
+  value: string
+  domain: string
+  path: string
+  expires?: number
+  httpOnly?: boolean
+  secure?: boolean
+  sameSite?: 'Strict' | 'Lax' | 'None'
+}
+
+export interface ServerCaptureOptions {
+  cookies?: ServerCaptureCookie[]
+}
+
 const VIEWPORT = { width: 1280, height: 720 } as const
 const NAVIGATION_TIMEOUT_MS = 15_000
 const SETTLE_TIMEOUT_MS = 5_000
 
 export default class ServerCaptureProvider {
-  async capture(url: string): Promise<ServerCaptureResult> {
+  async capture(url: string, options: ServerCaptureOptions = {}): Promise<ServerCaptureResult> {
     const { chromium } = await import('playwright')
     const browser = await chromium.launch({ headless: true })
 
     try {
-      const page = await browser.newPage({
+      const context = await browser.newContext({
         viewport: VIEWPORT,
         deviceScaleFactor: 1,
       })
 
-      await page.goto(url, {
-        waitUntil: 'domcontentloaded',
-        timeout: NAVIGATION_TIMEOUT_MS,
-      })
-      await page.waitForLoadState('networkidle', { timeout: SETTLE_TIMEOUT_MS }).catch(() => {})
+      try {
+        if (options.cookies?.length) {
+          await context.addCookies(options.cookies).catch(() => {})
+        }
 
-      const buffer = await page.screenshot({
-        type: 'png',
-        fullPage: false,
-        animations: 'disabled',
-      })
+        const page = await context.newPage()
 
-      return {
-        buffer,
-        width: VIEWPORT.width,
-        height: VIEWPORT.height,
+        await page.goto(url, {
+          waitUntil: 'domcontentloaded',
+          timeout: NAVIGATION_TIMEOUT_MS,
+        })
+        await page.waitForLoadState('networkidle', { timeout: SETTLE_TIMEOUT_MS }).catch(() => {})
+
+        const buffer = await page.screenshot({
+          type: 'png',
+          fullPage: false,
+          animations: 'disabled',
+        })
+
+        return {
+          buffer,
+          width: VIEWPORT.width,
+          height: VIEWPORT.height,
+        }
+      } finally {
+        await context.close()
       }
     } finally {
       await browser.close()

--- a/apps/api/tests/functional/bookmarks.spec.ts
+++ b/apps/api/tests/functional/bookmarks.spec.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
 import app from '@adonisjs/core/services/app'
+import db from '@adonisjs/lucid/services/db'
 import { test } from '@japa/runner'
 import { hashUrl, normalizeUrl } from '@stashbox/shared'
 
@@ -12,6 +13,45 @@ import { authHeader } from '#tests/helpers/api_key'
 
 const pngDataUrl =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
+
+const siteCredentialCookie = {
+  name: 'sid',
+  value: 'secret-cookie-value',
+  domain: '.example.com',
+  path: '/',
+  secure: true,
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  expirationDate: 1_893_456_000,
+  session: false,
+  hostOnly: false,
+}
+
+interface CapturedServerCapture {
+  url: string
+  cookies?: Array<Record<string, unknown>>
+}
+
+function swapSuccessfulServerCapture(): CapturedServerCapture {
+  const captured: CapturedServerCapture = { url: '' }
+  app.container.swap(
+    ServerCaptureProvider,
+    () =>
+      ({
+        capture: async (url: string, options?: { cookies?: Array<Record<string, unknown>> }) => {
+          captured.url = url
+          captured.cookies = options?.cookies
+          return {
+            buffer: Buffer.from(pngDataUrl.split(',')[1], 'base64'),
+            width: 1280,
+            height: 720,
+          }
+        },
+      }) as unknown as ServerCaptureProvider
+  )
+
+  return captured
+}
 
 test.group('POST /bookmarks', (group) => {
   let auth: { Authorization: string }
@@ -47,21 +87,7 @@ test.group('POST /bookmarks', (group) => {
     client,
     assert,
   }) => {
-    let capturedUrl = ''
-    app.container.swap(
-      ServerCaptureProvider,
-      () =>
-        ({
-          capture: async (url: string) => {
-            capturedUrl = url
-            return {
-              buffer: Buffer.from(pngDataUrl.split(',')[1], 'base64'),
-              width: 1280,
-              height: 720,
-            }
-          },
-        }) as unknown as ServerCaptureProvider
-    )
+    const captured = swapSuccessfulServerCapture()
 
     const created = await client
       .post('/bookmarks')
@@ -79,7 +105,8 @@ test.group('POST /bookmarks', (group) => {
     after.assertStatus(200)
 
     const capture = after.body().capture
-    assert.equal(capturedUrl, 'https://example.com/server-capture')
+    assert.equal(captured.url, 'https://example.com/server-capture')
+    assert.deepEqual(captured.cookies, [])
     assert.equal(capture.source, 'server')
     assert.equal(capture.mimeType, 'image/png')
     assert.equal(capture.width, 1280)
@@ -90,6 +117,109 @@ test.group('POST /bookmarks', (group) => {
     const image = await client.get(new URL(capture.url).pathname)
     image.assertStatus(200)
     assert.include(String(image.header('content-type')), 'image/png')
+  })
+
+  test('uses matching Site credentials for server capture', async ({ client, assert }) => {
+    const captured = swapSuccessfulServerCapture()
+
+    const synced = await client
+      .post('/site-credentials/sync')
+      .headers(auth)
+      .json({ domain: 'example.com', cookies: [siteCredentialCookie] })
+    synced.assertStatus(200)
+
+    const created = await client
+      .post('/bookmarks')
+      .headers({ ...auth, host: 'api.local:4567' })
+      .json({ url: 'https://example.com/private' })
+    created.assertStatus(201)
+
+    await captureQueue.flush()
+
+    const after = await client
+      .get(`/bookmarks/${created.body().id}`)
+      .headers({ ...auth, host: 'api.local:4567' })
+    after.assertStatus(200)
+
+    assert.equal(captured.url, 'https://example.com/private')
+    assert.deepEqual(captured.cookies, [
+      {
+        name: 'sid',
+        value: 'secret-cookie-value',
+        domain: '.example.com',
+        path: '/',
+        secure: true,
+        httpOnly: true,
+        sameSite: 'Lax',
+        expires: 1_893_456_000,
+      },
+    ])
+    assert.isFalse(JSON.stringify(created.body()).includes('secret-cookie-value'))
+    assert.isFalse(JSON.stringify(after.body()).includes('secret-cookie-value'))
+    assert.equal(after.body().capture.source, 'server')
+  })
+
+  test('uses parent-domain Site credentials for server capture subdomains', async ({
+    client,
+    assert,
+  }) => {
+    const captured = swapSuccessfulServerCapture()
+
+    const synced = await client
+      .post('/site-credentials/sync')
+      .headers(auth)
+      .json({ domain: 'example.com', cookies: [siteCredentialCookie] })
+    synced.assertStatus(200)
+
+    const created = await client
+      .post('/bookmarks')
+      .headers({ ...auth, host: 'api.local:4567' })
+      .json({ url: 'https://private.example.com/account' })
+    created.assertStatus(201)
+
+    await captureQueue.flush()
+
+    assert.equal(captured.url, 'https://private.example.com/account')
+    assert.deepEqual(captured.cookies, [
+      {
+        name: 'sid',
+        value: 'secret-cookie-value',
+        domain: '.example.com',
+        path: '/',
+        secure: true,
+        httpOnly: true,
+        sameSite: 'Lax',
+        expires: 1_893_456_000,
+      },
+    ])
+  })
+
+  test('ignores invalid Site credentials during server capture', async ({ client, assert }) => {
+    const captured = swapSuccessfulServerCapture()
+
+    await db.table('site_credentials').insert({
+      domain: 'example.com',
+      encrypted_cookies: 'invalid-ciphertext',
+      cookie_count: 1,
+    })
+
+    const created = await client
+      .post('/bookmarks')
+      .headers({ ...auth, host: 'api.local:4567' })
+      .json({ url: 'https://example.com/private-invalid-cookie' })
+    created.assertStatus(201)
+
+    await captureQueue.flush()
+
+    const after = await client
+      .get(`/bookmarks/${created.body().id}`)
+      .headers({ ...auth, host: 'api.local:4567' })
+    after.assertStatus(200)
+
+    assert.equal(captured.url, 'https://example.com/private-invalid-cookie')
+    assert.deepEqual(captured.cookies, [])
+    assert.equal(after.body().capture.source, 'server')
+    assert.isFalse(JSON.stringify(after.body()).includes('invalid-ciphertext'))
   })
 
   test('keeps capture failures isolated from enrichment state', async ({ client, assert }) => {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,36 @@
+# Issue 57 - Use Site Credentials For Server Capture
+
+## Plan
+
+- [x] Read GitHub issue #57 and create draft PR linked with `Closes #57`.
+- [x] RED 1: Server Capture job for `https://example.com/...` uses synced `example.com` Site credentials and passes sanitized cookies into Playwright before navigation.
+- [x] GREEN 1: Add credential lookup/decryption for capture by URL domain and extend `ServerCaptureProvider.capture` options.
+- [x] RED 2: Subdomain URL uses parent-domain credentials where cookie domain rules allow it.
+- [x] GREEN 2: implement domain matching compatible with stored normalized credential domains and cookie domain/path/security rules.
+- [x] RED/GREEN 3: missing credentials still captures unauthenticated without failing the job.
+- [x] GREEN 3: keep no-credentials path identical to #55 behavior.
+- [x] RED 4: invalid/decryption-failed credentials degrade gracefully and never leak raw cookie values in capture responses/logs.
+- [x] GREEN 4: isolate credential errors and avoid logging cookie payloads.
+- [x] Verify API tests, targeted lint/prettier/typecheck, and Playwright cookie injection smoke if feasible.
+
+## Review
+
+- Server Capture now loads matching Site credentials by URL host/domain candidates.
+- Matching cookies are decrypted, filtered by domain/path/security rules, converted to Playwright cookie options, and injected before navigation.
+- Missing or invalid credentials fall back to unauthenticated Server Capture.
+- Bookmark/Capture API responses still avoid raw credential exposure; existing Site credentials metadata-only tests pass.
+- Verified targeted API specs, API typecheck, changed-file lint, `git diff --check`, and a real Playwright cookie-injection smoke.
+- Full package lint still fails on existing generated/baseline files under `.adonisjs`, config, and `database/schema.ts`.
+
+## Scope
+
+- Apps/packages: `apps/api` primarily.
+- Public behavior: existing Site credentials APIs remain metadata-only; existing Bookmark/Capture responses do not expose cookies.
+- Worker behavior: Server Capture uses matching stored cookies before page navigation, but missing/invalid credentials do not block capture.
+- Out of scope: UI changes to credential management (#56 already covers sync/list/delete), Groq transcription, new credential schema.
+
+---
+
 # Issue 55 - Server Capture for URL-only Saves
 
 ## Plan


### PR DESCRIPTION
Closes #57

## Summary

- Use stored Site credentials during Server Capture so authenticated pages can render with saved cookies.
- Match credentials by URL domain/subdomain, decrypt cookies, filter them for the target URL, and inject them into Playwright before navigation.
- Keep missing, corrupt, or Playwright-rejected cookies best-effort so capture falls back to unauthenticated rendering.

## Test plan

- [x] pnpm --filter @stashbox/api test -- --files tests/functional/bookmarks.spec.ts
- [x] pnpm --filter @stashbox/api test -- --files tests/functional/site_credentials.spec.ts
- [x] pnpm --filter @stashbox/api typecheck
- [x] pnpm --filter @stashbox/api exec eslint app/jobs/capture_bookmark_job.ts app/services/server_capture_credentials.ts app/services/server_capture_provider.ts tests/functional/bookmarks.spec.ts
- [x] pnpm exec prettier --check apps/api/app/jobs/capture_bookmark_job.ts apps/api/app/services/server_capture_credentials.ts apps/api/app/services/server_capture_provider.ts apps/api/tests/functional/bookmarks.spec.ts tasks/todo.md
- [x] git diff --check
- [x] Playwright cookie injection smoke with local HTTP server
- [x] commit hook: turbo run typecheck && turbo run test

## Notes

Full package lint still has pre-existing generated/baseline failures in `.adonisjs`, config, and `database/schema.ts`; changed-file lint passes.